### PR TITLE
feat(backend): update VLM prompts with category context

### DIFF
--- a/backend/app/services/categories.py
+++ b/backend/app/services/categories.py
@@ -250,3 +250,39 @@ FACE_CATEGORIES: dict[str, FaceCategory] = {
         ),
     ),
 }
+
+# ---------------------------------------------------------------------------
+# GradCAM label → category mapping
+# ---------------------------------------------------------------------------
+
+# Maps the free-text region labels produced by gradcam_service._label_region()
+# to the corresponding FACE_CATEGORIES key.  Any label not present here is
+# treated as uncategorised (get_category_for_label returns None).
+GRADCAM_LABEL_TO_CATEGORY_ID: dict[str, str] = {
+    "Forehead and hairline region": "hairline_ears",
+    "Left eye region": "eyes_pupils",
+    "Right eye region": "eyes_pupils",
+    "Eye and nose bridge region": "eyes_pupils",
+    "Left cheek region": "skin_texture",
+    "Right cheek region": "skin_texture",
+    "Nose and mid-face region": "facial_boundaries",
+    "Left jaw region": "facial_boundaries",
+    "Right jaw region": "facial_boundaries",
+    "Chin and jawline region": "facial_boundaries",
+}
+
+
+def get_category_for_label(label: str) -> FaceCategory | None:
+    """Return the FaceCategory for a GradCAM region label, or None if unmapped.
+
+    Args:
+        label: Free-text label produced by gradcam_service._label_region().
+
+    Returns:
+        Matching FaceCategory instance, or None when the label is not in
+        GRADCAM_LABEL_TO_CATEGORY_ID.
+    """
+    category_id = GRADCAM_LABEL_TO_CATEGORY_ID.get(label)
+    if category_id is None:
+        return None
+    return FACE_CATEGORIES.get(category_id)

--- a/backend/app/services/vlm/base.py
+++ b/backend/app/services/vlm/base.py
@@ -47,6 +47,27 @@ class ProviderInfo:
 
 
 @dataclass
+class RegionWithCategory:
+    """A GradCAM region label enriched with face category metadata.
+
+    Produced by pairing a raw region label from gradcam_service with its
+    matching FaceCategory via categories.get_category_for_label().
+
+    Attributes:
+        label: Original free-text label from GradCAM (e.g. "Left eye region").
+        category_id: Stable snake_case category key (e.g. "eyes_pupils").
+        category_label: Human-readable display label (e.g. "Eyes & Pupils").
+        common_artifacts: First N artifact descriptions from the FaceCategory,
+            used as guidance hints in VLM prompts.
+    """
+
+    label: str
+    category_id: str
+    category_label: str
+    common_artifacts: tuple[str, ...]
+
+
+@dataclass
 class DetectionContext:
     """Detection results passed to VLM for grounded explanations."""
 
@@ -57,6 +78,10 @@ class DetectionContext:
     # Labeled facial regions from GradCAM evidence crops
     # e.g. ["Nose and mid-face region", "Left eye region"]
     region_labels: list = field(default_factory=list)
+    # Category-enriched versions of region_labels — populated when
+    # categories.get_category_for_label() resolves a label successfully.
+    # Providers and prompt_builder prefer this over plain region_labels.
+    region_categories: list[RegionWithCategory] = field(default_factory=list)
 
 
 class BaseVLMProvider(ABC):

--- a/backend/app/services/vlm/prompt_builder.py
+++ b/backend/app/services/vlm/prompt_builder.py
@@ -36,6 +36,8 @@ inconsistent lighting, texture anomalies, or color artifacts
 - Do not use long dashes. Use commas or short sentences instead
 - Be specific and concrete
 - If region labels are provided, write a one-sentence comment for each in the [REGIONS] section
+- When artifact hints are listed for a region, use them to direct your observation — do not repeat \
+them verbatim, but let them focus what you look for in that area
 
 Here are three examples of the tone and style you should follow:
 
@@ -119,8 +121,17 @@ def build_explanation_prompt(
     """
     Build the user-facing prompt with detection context and region labels.
 
+    When detection.region_categories is populated, each region entry is enriched
+    with its category label and the top three artifact hints from that category.
+    This gives the VLM targeted vocabulary for what to look for in each zone
+    rather than just a spatial description.
+
+    Falls back to plain region_labels when region_categories is empty, so
+    existing callers that have not yet been updated remain fully compatible.
+
     Args:
-        detection: Detection results including region_labels from GradCAM crops.
+        detection: Detection results including region_labels and, when available,
+            region_categories enriched with FaceCategory metadata.
         gradcam_available: Whether a valid GradCAM heatmap was generated.
 
     Returns:
@@ -144,9 +155,25 @@ def build_explanation_prompt(
             "you can directly observe that support or contradict this classification."
         )
 
-    # Add region labels if available so VLM can comment on each crop
     regions_instruction = ""
-    if detection.region_labels:
+
+    if detection.region_categories:
+        # Enriched path: include category label + top-3 artifact hints per region
+        lines = []
+        for rc in detection.region_categories:
+            hints = ", ".join(rc.common_artifacts[:3])
+            lines.append(f"- {rc.label} [Category: {rc.category_label} | Look for: {hints}]")
+        labels_list = "\n".join(lines)
+        regions_instruction = (
+            f"\n\nThe following facial regions were highlighted by the model. "
+            f"Each entry includes a semantic category and known artifact types as guidance. "
+            f"In the [REGIONS] section, write one sentence for each explaining what you "
+            f"observe there — use the artifact hints to direct your eye, but describe what "
+            f"you actually see rather than repeating the hints verbatim:\n"
+            f"{labels_list}"
+        )
+    elif detection.region_labels:
+        # Fallback path: plain labels with no category context
         labels_list = "\n".join(f"- {label}" for label in detection.region_labels)
         regions_instruction = (
             f"\n\nThe following facial regions were highlighted by the model. "


### PR DESCRIPTION
## Summary

- Extends `categories.py` with a `GRADCAM_LABEL_TO_CATEGORY_ID` mapping and
  `get_category_for_label()` lookup, bridging GradCAM spatial labels to the
  structured `FaceCategory` taxonomy from #62
- Adds `RegionWithCategory` dataclass to `vlm/base.py` — pairs a raw GradCAM
  label with its `category_id`, `category_label`, and `common_artifacts`
- Adds `region_categories: list[RegionWithCategory]` to `DetectionContext`;
  defaults to empty list so all existing callers are unaffected
- `build_explanation_prompt()` now emits per-region artifact hints when
  `region_categories` is populated, e.g.
  `- Left eye region [Category: Eyes & Pupils | Look for: pupil shape asymmetry, ...]`
- System prompt updated with a rule instructing the VLM to use artifact hints
  to direct observation rather than repeating them verbatim

Closes #64

## Test plan

- [ ] `ruff check` and `ruff format --check` pass
- [ ] `from app.services.categories import get_category_for_label` resolves correctly
- [ ] Manually verify enriched prompt output by calling `build_explanation_prompt()`
  with a `DetectionContext` that has `region_categories` populated
- [ ] Verify fallback: plain `region_labels` still works when `region_categories` is empty
