### PR TITLE
feat: rule-based provider, region-aware VLM pipeline, MediaPipe Task migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ real_vs_fake/
 *.pickle
 *.safetensors
 *.bin
+*.task
 
 # BUT keep checkpoint metadata (small JSON files)
 !backend/checkpoints/*.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,11 +34,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxext6 \
     libxrender-dev \
     libgl1 \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /install /usr/local
 COPY app/ ./app/
 COPY pyproject.toml .
+
+# Download the MediaPipe Face Landmarker model (float16, ~6 MB)
+RUN mkdir -p /app/models && \
+    wget -q -O /app/models/face_landmarker.task \
+    "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task"
 
 ENV HF_HOME=/app/.cache/huggingface
 

--- a/backend/app/routers/analyses.py
+++ b/backend/app/routers/analyses.py
@@ -105,10 +105,16 @@ def _run_gradcam(
     image: Image.Image,
     image_tensor: torch.Tensor,
     target_class: int,
+    face_bbox: tuple[int, int, int, int] | None = None,
 ) -> tuple[bytes | None, str | None, list[dict], list[dict]]:
     """
     Run GradCAM on the image and return heatmap bytes for VLM, a local URL
     for the frontend, a list of saved evidence regions, and the raw crops.
+
+    Args:
+        face_bbox: Optional face bounding box (x1, y1, x2, y2) used to mask
+            background activations before region extraction. Regions that fall
+            entirely outside the face will never appear in results.
 
     Returns:
         Tuple of (heatmap_bytes, gradcam_heatmap_url, evidence_regions, crops)
@@ -136,7 +142,7 @@ def _run_gradcam(
         overlay.save(buffer, format="PNG")
         heatmap_bytes = buffer.getvalue()
 
-        crops = generator.extract_evidence_regions(image, heatmap)
+        crops = generator.extract_evidence_regions(image, heatmap, face_bbox=face_bbox)
         evidence_regions = save_evidence_crops(crops)
 
         return heatmap_bytes, gradcam_heatmap_url, evidence_regions, crops
@@ -316,11 +322,24 @@ async def create_analysis(request: AnalysisRequest):
             processing_time = int((time.time() - start_time) * 1000)
             classification = prediction if prediction in ("fake", "real") else "uncertain"
 
+            # Detect face bbox before GradCAM so background activations can
+            # be masked out. Falls back gracefully if no face is detected.
+            face_bbox = None
+            if face_category_mapper is not None:
+                try:
+                    face_bbox = face_category_mapper.detect_face_bbox(image)
+                    if face_bbox:
+                        logger.debug("Face bbox detected: %s", face_bbox)
+                    else:
+                        logger.debug("No face detected — GradCAM will run unmasked")
+                except Exception as e:
+                    logger.warning("Face bbox detection failed: %s", e)
+
             # Run GradCAM — returns None heatmap_bytes if it failed.
             # crops retains PIL image + bbox needed by the mapper;
             # evidence_regions has the saved URLs for the API response.
             heatmap_bytes, gradcam_heatmap_url, evidence_regions, crops = _run_gradcam(
-                image, image_tensor, target_class
+                image, image_tensor, target_class, face_bbox=face_bbox
             )
 
             # gradcam_available drives both the VLM prompt and whether
@@ -363,12 +382,20 @@ async def create_analysis(request: AnalysisRequest):
                         region_categories=region_categories,
                     )
 
+                    # Convert region crop PIL images to JPEG bytes for VLM
+                    region_image_bytes = []
+                    for crop in crops:
+                        buf = io.BytesIO()
+                        crop["image"].save(buf, format="JPEG", quality=90)
+                        region_image_bytes.append(buf.getvalue())
+
                     vlm_explanation = await vlm_factory.generate_explanation(
                         provider_id=request.vlm_provider,
                         image_bytes=image_bytes,
                         heatmap_bytes=heatmap_bytes if gradcam_available else image_bytes,
                         detection=detection_context,
                         gradcam_available=gradcam_available,
+                        region_image_bytes=region_image_bytes if region_image_bytes else None,
                     )
 
                     print("VLM raw response:", vlm_explanation.raw_response)

--- a/backend/app/services/face_category_mapper.py
+++ b/backend/app/services/face_category_mapper.py
@@ -20,13 +20,20 @@ overlap_confidence 0.0.
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 
 import mediapipe as mp
 import numpy as np
+from mediapipe.tasks import python as mp_python
+from mediapipe.tasks.python import vision as mp_vision
 from PIL import Image
 
 from app.services.categories import FACE_CATEGORIES, get_category_for_label
 from app.services.vlm.base import RegionWithCategory
+
+# Resolve model path relative to this file so it works both locally
+# (backend/models/) and inside Docker (/app/models/).
+_MODEL_PATH = Path(__file__).parent.parent.parent / "models" / "face_landmarker.task"
 
 logger = logging.getLogger(__name__)
 
@@ -96,12 +103,21 @@ class FaceCategoryMapper:
     """
 
     def __init__(self) -> None:
-        self._face_mesh = mp.solutions.face_mesh.FaceMesh(
-            static_image_mode=True,
-            max_num_faces=1,
-            refine_landmarks=False,
-            min_detection_confidence=0.5,
+        if not _MODEL_PATH.exists():
+            raise FileNotFoundError(
+                f"MediaPipe face landmarker model not found at {_MODEL_PATH}. "
+                "Download it with: curl -L -o backend/models/face_landmarker.task "
+                "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task"
+            )
+        options = mp_vision.FaceLandmarkerOptions(
+            base_options=mp_python.BaseOptions(model_asset_path=str(_MODEL_PATH)),
+            running_mode=mp_vision.RunningMode.IMAGE,
+            num_faces=1,
+            min_face_detection_confidence=0.5,
+            output_face_blendshapes=False,
+            output_facial_transformation_matrixes=False,
         )
+        self._landmarker = mp_vision.FaceLandmarker.create_from_options(options)
         self._landmark_to_category_id: dict[int, str] = self._build_landmark_map()
         logger.info(
             "FaceCategoryMapper initialised (%d landmark mappings)",
@@ -120,6 +136,40 @@ class FaceCategoryMapper:
             for idx in cat.landmark_indices:
                 mapping[idx] = cat_id
         return mapping
+
+    def detect_face_bbox(
+        self,
+        image: Image.Image,
+        padding_pct: float = 0.05,
+    ) -> tuple[int, int, int, int] | None:
+        """Return a padded bounding box around the detected face.
+
+        Args:
+            image: PIL image to run landmark detection on.
+            padding_pct: Fraction of image dimensions to pad outward from the
+                tight landmark bbox (default 5%).
+
+        Returns:
+            (x1, y1, x2, y2) in pixel coordinates, clipped to image bounds,
+            or None if no face was detected.
+        """
+        landmarks_px = self._detect_landmarks(image)
+        if landmarks_px is None:
+            return None
+
+        width, height = image.size
+        xs = [lm[0] for lm in landmarks_px]
+        ys = [lm[1] for lm in landmarks_px]
+
+        pad_x = int(width * padding_pct)
+        pad_y = int(height * padding_pct)
+
+        x1 = max(0, min(xs) - pad_x)
+        y1 = max(0, min(ys) - pad_y)
+        x2 = min(width, max(xs) + pad_x)
+        y2 = min(height, max(ys) + pad_y)
+
+        return (x1, y1, x2, y2)
 
     def map_regions(
         self,
@@ -151,7 +201,7 @@ class FaceCategoryMapper:
         self,
         image: Image.Image,
     ) -> list[tuple[int, int]] | None:
-        """Run MediaPipe Face Mesh and return pixel-space landmark coordinates.
+        """Run MediaPipe Face Landmarker and return pixel-space landmark coordinates.
 
         Args:
             image: Input PIL image (any mode; converted to RGB internally).
@@ -161,14 +211,15 @@ class FaceCategoryMapper:
             when no face is detected.
         """
         rgb = np.array(image.convert("RGB"))
-        result = self._face_mesh.process(rgb)
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
+        result = self._landmarker.detect(mp_image)
 
-        if not result.multi_face_landmarks:
+        if not result.face_landmarks:
             return None
 
         width, height = image.size
-        face = result.multi_face_landmarks[0]
-        return [(int(lm.x * width), int(lm.y * height)) for lm in face.landmark]
+        face = result.face_landmarks[0]
+        return [(int(lm.x * width), int(lm.y * height)) for lm in face]
 
     def _categorize_region(
         self,
@@ -250,8 +301,8 @@ class FaceCategoryMapper:
         )
 
     def close(self) -> None:
-        """Release MediaPipe Face Mesh resources."""
-        self._face_mesh.close()
+        """Release MediaPipe Face Landmarker resources."""
+        self._landmarker.close()
 
     def __enter__(self) -> "FaceCategoryMapper":
         return self

--- a/backend/app/services/gradcam_service.py
+++ b/backend/app/services/gradcam_service.py
@@ -202,64 +202,161 @@ class GradCAMGenerator:
         self,
         original_image: Image.Image,
         heatmap: np.ndarray,
+        max_regions: int = 3,
+        face_bbox: Optional[tuple[int, int, int, int]] = None,
     ) -> list[dict]:
         """
-        Extract a single crop centered on the peak activation zone of the heatmap.
+        Extract up to max_regions distinct crops from the GradCAM heatmap.
 
-        Uses the centroid of all high-activation pixels (top 30% of activation)
-        to find the true center of the most suspicious area, then crops a region
-        around it. This guarantees the crop, label, and activation score all
-        refer to the same actual area in the image.
+        Uses connected-component analysis on the top-50% activation mask to
+        find spatially separate high-activation blobs. Each blob becomes one
+        evidence region with a tight, zoomed-in crop and its own label and
+        activation score.
+
+        Falls back to a single centroid-based crop if no distinct components
+        are found above the size threshold.
 
         Args:
             original_image: The original PIL image.
             heatmap: Normalized heatmap array (H x W) with values in [0, 1].
+            max_regions: Maximum number of regions to return (default 3).
+            face_bbox: Optional (x1, y1, x2, y2) bounding box of the detected
+                face. When provided, heatmap activations outside this box are
+                zeroed before connected-component analysis so that background
+                regions are never returned as evidence crops.
 
         Returns:
-            List containing exactly one dict with keys:
+            List of up to max_regions dicts, each with keys:
               image (PIL), label (str), activation_score (float), bbox (tuple).
+            Sorted by activation_score descending.
         """
         width, height = original_image.size
         heatmap_resized = cv2.resize(heatmap, (width, height))
 
-        # Find centroid of the top-30% activation zone
-        threshold = heatmap_resized.max() * 0.70
-        hot_mask = heatmap_resized >= threshold
+        # Mask out background activations when a face bbox is available
+        if face_bbox is not None:
+            fx1, fy1, fx2, fy2 = face_bbox
+            mask = np.zeros_like(heatmap_resized)
+            mask[fy1:fy2, fx1:fx2] = 1.0
+            heatmap_resized = heatmap_resized * mask
 
-        if hot_mask.sum() > 0:
-            ys, xs = np.where(hot_mask)
-            weights = heatmap_resized[ys, xs]
-            cx_px = int(np.average(xs, weights=weights))
-            cy_px = int(np.average(ys, weights=weights))
-            activation_score = float(heatmap_resized[ys, xs].mean())
+        # Two-pass thresholding: use a tighter threshold (50%) to find distinct
+        # blobs, then expand each blob's crop boundary down to 35% to capture
+        # the full activation region. This avoids merging separate face areas
+        # (e.g. forehead + nose) into one large centroid-averaged blob.
+        threshold_blob = heatmap_resized.max() * 0.50
+        binary = (heatmap_resized >= threshold_blob).astype(np.uint8)
+
+        # Connected components — each distinct blob is a candidate region
+        num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(binary)
+
+        # Minimum blob area: 1% of image area
+        min_area = width * height * 0.010
+        # Padding around each blob's tight bbox
+        pad = max(20, int(min(width, height) * 0.06))
+
+        # Minimum crop dimensions — ensure every crop shows enough face context.
+        # When we have a face bbox use 28% of face dimensions; otherwise 18% of image.
+        if face_bbox is not None:
+            fx1, fy1, fx2, fy2 = face_bbox
+            face_w = fx2 - fx1
+            face_h = fy2 - fy1
+            min_crop_half_w = int(face_w * 0.28)
+            min_crop_half_h = int(face_h * 0.28)
         else:
-            # Absolute fallback: peak pixel
+            min_crop_half_w = int(width * 0.18)
+            min_crop_half_h = int(height * 0.18)
+
+        components = []
+        for i in range(1, num_labels):  # 0 is background
+            area = int(stats[i, cv2.CC_STAT_AREA])
+            if area < min_area:
+                continue
+
+            mask = labels == i
+            activation_score = float(heatmap_resized[mask].mean())
+
+            # Use the PEAK activation pixel (not the geometric centroid) for
+            # labeling and crop centering. The peak is always where the model
+            # actually focused most, so the label and crop will match the
+            # hottest part of the heatmap even when the blob extends further.
+            blob_activations = heatmap_resized * mask
+            peak_idx = np.unravel_index(np.argmax(blob_activations), blob_activations.shape)
+            cx_px, cy_px = int(peak_idx[1]), int(peak_idx[0])  # (col, row)
+
+            # Tight bbox from the blob itself, then add padding
+            bx = int(stats[i, cv2.CC_STAT_LEFT])
+            by = int(stats[i, cv2.CC_STAT_TOP])
+            bw = int(stats[i, cv2.CC_STAT_WIDTH])
+            bh = int(stats[i, cv2.CC_STAT_HEIGHT])
+
+            x1 = max(0, bx - pad)
+            y1 = max(0, by - pad)
+            x2 = min(width, bx + bw + pad)
+            y2 = min(height, by + bh + pad)
+
+            # Expand to minimum size centered on peak pixel so crops always
+            # show the actual focal area rather than an averaged midpoint.
+            if (x2 - x1) < min_crop_half_w * 2:
+                x1 = max(0, cx_px - min_crop_half_w)
+                x2 = min(width, cx_px + min_crop_half_w)
+            if (y2 - y1) < min_crop_half_h * 2:
+                y1 = max(0, cy_px - min_crop_half_h)
+                y2 = min(height, cy_px + min_crop_half_h)
+
+            components.append(
+                {
+                    # Peak-based coordinates for label and crop center
+                    "cx_norm": cx_px / width,
+                    "cy_norm": cy_px / height,
+                    "x1": x1,
+                    "y1": y1,
+                    "x2": x2,
+                    "y2": y2,
+                    "activation_score": activation_score,
+                }
+            )
+
+        # Sort by activation score, strongest first
+        components.sort(key=lambda c: c["activation_score"], reverse=True)
+
+        # Fallback: no blobs passed the size filter — use single peak centroid
+        if not components:
             cy_px, cx_px = np.unravel_index(np.argmax(heatmap_resized), heatmap_resized.shape)
             cx_px, cy_px = int(cx_px), int(cy_px)
             activation_score = float(heatmap_resized[cy_px, cx_px])
+            crop_half = max(min_crop_half_w, min_crop_half_h)
+            x1 = max(0, cx_px - crop_half)
+            y1 = max(0, cy_px - crop_half)
+            x2 = min(width, cx_px + crop_half)
+            y2 = min(height, cy_px + crop_half)
+            components = [
+                {
+                    "cx_norm": cx_px / width,
+                    "cy_norm": cy_px / height,
+                    "x1": x1,
+                    "y1": y1,
+                    "x2": x2,
+                    "y2": y2,
+                    "activation_score": activation_score,
+                }
+            ]
 
-        # Crop size: 40% of the shorter side, at least 80px
-        crop_half = max(80, int(min(width, height) * 0.20))
-        x1 = max(0, cx_px - crop_half)
-        y1 = max(0, cy_px - crop_half)
-        x2 = min(width, cx_px + crop_half)
-        y2 = min(height, cy_px + crop_half)
+        regions = []
+        for comp in components[:max_regions]:
+            x1, y1, x2, y2 = comp["x1"], comp["y1"], comp["x2"], comp["y2"]
+            crop = original_image.crop((x1, y1, x2, y2))
+            label = _label_region(comp["cx_norm"], comp["cy_norm"])
+            regions.append(
+                {
+                    "image": crop,
+                    "label": label,
+                    "activation_score": round(comp["activation_score"], 4),
+                    "bbox": (x1, y1, x2, y2),
+                }
+            )
 
-        crop = original_image.crop((x1, y1, x2, y2))
-
-        # Label based on the weighted centroid — guaranteed to match the crop
-        cx_norm = cx_px / width
-        cy_norm = cy_px / height
-        label = _label_region(cx_norm, cy_norm)
-
-        return [
-            {
-                "image": crop,
-                "label": label,
-                "activation_score": round(activation_score, 4),
-                "bbox": (x1, y1, x2, y2),
-            }
-        ]
+        return regions
 
 
 def _label_region(cx: float, cy: float) -> str:

--- a/backend/app/services/vlm/base.py
+++ b/backend/app/services/vlm/base.py
@@ -101,6 +101,7 @@ class BaseVLMProvider(ABC):
         heatmap_bytes: bytes,
         detection: DetectionContext,
         gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         """
         Generate a structured explanation from the VLM provider.
@@ -112,6 +113,11 @@ class BaseVLMProvider(ABC):
             detection: The detection results to ground the explanation.
                        Includes region_labels from GradCAM evidence crops.
             gradcam_available: Whether heatmap_bytes contains a real heatmap.
+            region_image_bytes: Optional list of zoomed-in region crop images
+                                in the same order as detection.region_categories.
+                                When provided, each crop is sent to the VLM as
+                                a separate image so it can inspect the artifact
+                                up close rather than inferring from the full image.
 
         Returns:
             VLMExplanation with summary, detailed analysis, technical notes,

--- a/backend/app/services/vlm/factory.py
+++ b/backend/app/services/vlm/factory.py
@@ -10,6 +10,7 @@ from typing import Optional
 from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInfo, VLMExplanation
 from app.services.vlm.config import VLMConfig
 from app.services.vlm.providers.mock import MockProvider
+from app.services.vlm.providers.rule_based import RuleBasedProvider
 from app.services.vlm.usage_tracker import UsageLimitExceeded, UsageTracker
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class VLMProviderFactory:
         self._providers: dict[str, BaseVLMProvider] = {}
         self._usage_tracker = UsageTracker(config)
         self._providers["mock"] = MockProvider()
+        self._providers["rule_based"] = RuleBasedProvider()
 
     def get_provider(self, provider_id: Optional[str] = None) -> BaseVLMProvider:
         if provider_id is None:
@@ -66,9 +68,13 @@ class VLMProviderFactory:
         elif provider_id == "mock":
             return MockProvider()
 
+        elif provider_id == "rule_based":
+            return RuleBasedProvider()
+
         else:
             raise ValueError(
-                f"Unknown VLM provider: '{provider_id}'. Available: google, openai, anthropic, mock"
+                f"Unknown VLM provider: '{provider_id}'. "
+                f"Available: google, openai, anthropic, mock, rule_based"
             )
 
     async def generate_explanation(
@@ -78,6 +84,7 @@ class VLMProviderFactory:
         heatmap_bytes: bytes,
         detection: DetectionContext,
         gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         """
         Generate an explanation using the specified provider.
@@ -88,6 +95,8 @@ class VLMProviderFactory:
             heatmap_bytes: GradCAM heatmap as bytes (only used when gradcam_available=True)
             detection: Detection results
             gradcam_available: Whether a real heatmap was generated
+            region_image_bytes: Zoomed-in crop images for each detected region,
+                                 sent to the VLM for close-up artifact inspection
         """
         resolved_id = provider_id or self._config.default_provider
 
@@ -117,6 +126,7 @@ class VLMProviderFactory:
             heatmap_bytes,
             detection,
             gradcam_available=gradcam_available,
+            region_image_bytes=region_image_bytes,
         )
 
         if resolved_id != "mock":
@@ -125,7 +135,10 @@ class VLMProviderFactory:
         return explanation
 
     def list_providers(self) -> list[ProviderInfo]:
-        providers = [MockProvider().get_provider_info()]
+        providers = [
+            MockProvider().get_provider_info(),
+            RuleBasedProvider().get_provider_info(),
+        ]
 
         if self._config.google.enabled:
             try:

--- a/backend/app/services/vlm/prompt_builder.py
+++ b/backend/app/services/vlm/prompt_builder.py
@@ -17,72 +17,101 @@ from app.services.vlm.base import DetectionContext
 SYSTEM_PROMPT_WITH_GRADCAM = """You are a forensic image analyst explaining deepfake detection results \
 to everyday users with no technical background.
 
-You will receive two images:
+You will receive images in this order:
 - Image 1: The original photo that was analyzed
 - Image 2: A GradCAM heatmap overlay. Warmer and brighter colors (red, orange, yellow) show \
-which regions the AI model paid most attention to when making its decision.
+which regions the AI detection model paid most attention to.
+- Images 3, 4, 5 (if present): Zoomed-in crops of the specific facial regions, in order from \
+highest to lowest activation. Study these carefully — they are the primary evidence.
 
-Your job is to look at both images and describe what you actually observe in the highlighted \
-regions. Do not just restate the classification label. Explain the visual evidence.
+LENGTH RULES — follow these strictly:
+- [SUMMARY]: 1 sentence. State what was found and where. Nothing more.
+- [DETAILED]: 2-3 sentences maximum. Describe the single most distinctive thing you observe \
+that makes this image look real or fake. Be direct. No filler phrases like "strongly support" \
+or "consistent with the classification".
+- [TECHNICAL]: 3-5 lines of forensic notes.
+- [REGIONS]: 2-3 sentences per region. This is where you go into detail. Each sentence must \
+describe something specific you can see.
 
-RULES:
-- Reference the heatmap colors directly when describing regions (e.g. "the bright red area around the jaw")
-- Describe specific visual details you observe in those regions such as blurring, unnatural edges, \
-inconsistent lighting, texture anomalies, or color artifacts
-- If classified as real, describe what natural and consistent features appear in the highlighted areas
-- If classified as fake, describe the specific anomalies or artifacts visible in the highlighted areas
-- Never say "the model classified this as fake therefore it is fake". Show the visual evidence instead
-- Write naturally as if explaining to a friend. Avoid jargon except in the technical section
-- Do not use long dashes. Use commas or short sentences instead
-- Be specific and concrete
-- If region labels are provided, write a one-sentence comment for each in the [REGIONS] section
-- When artifact hints are listed for a region, use them to direct your observation — do not repeat \
-them verbatim, but let them focus what you look for in that area
+COVERAGE RULES — very important:
+- The GradCAM crops show where the detection model focused, but they are not the whole story.
+- After examining the crops, also look at the full original photo (Image 1) and scan the \
+entire face: hair and hairline, eyes and eyebrows, nose, mouth, jaw, skin tone, ears.
+- If you notice anything suspicious or anything that looks unusually clean or off anywhere \
+in the full photo, add it as an extra region in [REGIONS] even if the heatmap did not \
+highlight it. Label it clearly (e.g. "Hair and eyebrows", "Left eye", "Skin tone overall").
+- Aim to comment on at least 3 distinct facial areas total, mixing GradCAM regions and your \
+own observations from the full photo.
+- If the image is classified as real, scan the same areas and note what looks natural.
 
-Here are three examples of the tone and style you should follow:
+QUALITY RULES:
+- Every sentence must reference something you can actually see, not a general pattern
+- Describe what things look like: smooth, blurry, sharp, plastic, flat, uneven, too clean
+- Do not repeat the same observation across regions
+- Use plain everyday language — write as if explaining to a friend, not a scientist
+- Forbidden words and phrases: "composite artifact", "compositing", "face-swap", \
+"synthetic", "anomaly", "indicates manipulation", "consistent with", "strongly suggests", \
+"digital alteration", "forensic"
+- Instead of "synthetic skin" say "skin that looks too smooth to be real"
+- Instead of "composite artifact" say "a line where the blending wasn't quite right"
+- Avoid "this image" — describe what you see instead
 
-EXAMPLE 1 - Clear Fake:
+Here are examples of the correct length and style:
+
+EXAMPLE 1 - Clear Fake (jaw crop provided, but also scanning full photo):
 [SUMMARY]
-This image has been digitally manipulated. The heatmap reveals unnatural blending around the jawline and eyes that is inconsistent with a real photograph.
+The jaw and mouth area look clearly off, and scanning the full photo also reveals problems in the hair and eyes.
 
 [DETAILED]
-As you can see in the heatmap, the model focused heavily on the area around the jaw and the left cheek, shown in bright red. If you look at those regions in the original image, the skin texture has a smudged, slightly plastic quality, like the face has been smoothed over in a way that real skin simply does not look. Around the eye corners there is also a subtle blurriness where the generated face meets the original, which is a classic sign of a face swap. The model is 94% confident this is a deepfake, and looking at the heatmap it is easy to see why it zeroed in on those transition zones.
+The jaw in the crop has a surface that is too smooth, almost like a plastic mask rather than real skin. Along the lower edge of the jaw there is a faint line where the skin color changes slightly, which is where two images were joined and the tones did not quite match.
 
 [TECHNICAL]
-The strongest activations are concentrated along the facial boundary regions, including the jaw, cheekbones, and the area around the eyes. These are typically where face swapping models struggle most with seamless blending. The activation pattern is asymmetric, with higher attention on the left side of the face, suggesting the synthetic region may not perfectly mirror the natural lighting. One caveat is that high quality deepfakes trained on similar data may still evade detection in the lower attention regions.
+GradCAM activation peak: jaw region (67%), secondary: cheek (41%).
+Activation pattern: localised bilateral jaw concentration.
+EfficientNet-B4 fake probability: 94%.
 
 [REGIONS]
-Chin and jawline region | The bright red activation here highlights an unnatural smoothing of the jaw contour, where the blending between the synthetic face and the original neck creates a subtle but visible seam.
-Left eye region | Yellow activation around the left eye reveals slight asymmetry in the eyelid crease that is inconsistent with the right side, a common artifact in face swap generation.
+Left jaw region | The skin here looks almost airbrushed, with no visible pores or fine hairs and a slightly waxy, over-smoothed quality. Where the jaw meets the neck there is a faint line where the skin tone changes very slightly, like two photos joined together that were not quite the same brightness. Real skin at this angle would have subtle texture and variation, but this area is unusually flat.
+Right jaw region | The teeth in this crop are unnaturally uniform, all the same brightness, and the edge between the teeth and the gum line looks too sharp and clean. The gum tissue is flat and one solid color, whereas real gums have a slight gradation in tone and visible texture.
+Hair | Looking at the full photo, the hair has a very uniform, almost painted quality with no individual strands visible at the edges. Real hair always has some loose strands and slight fuzziness, but here the hair just ends in a clean sharp line.
+Eyes | The eyes in the full photo are glassy and both reflections are nearly identical and perfectly centered, which almost never happens in real photos where light comes from one side. Real eyes also show tiny variations in the iris that are not visible here.
 
-EXAMPLE 2 - Clear Real:
+EXAMPLE 2 - Clear Real (eyes crop provided, also scanning full photo):
 [SUMMARY]
-This appears to be an authentic photograph. The heatmap highlights naturally consistent facial features with no signs of digital manipulation.
+The face looks like a real photograph, with natural detail throughout the eyes, hair, and skin.
 
 [DETAILED]
-The heatmap shows the model paying close attention to the eyes and nose bridge, highlighted in orange and yellow. Looking at those areas in the original photo, you can see natural skin texture, consistent light reflection in the eyes, and the subtle asymmetry that real human faces have. These are things that AI generated faces often get slightly wrong. The texture around the highlighted zones looks organic and continuous, with no blurring or color bleeding at the edges. The model is 97% confident this is a real image, and the heatmap supports that since there are no suspicious boundaries or smoothed over regions.
+Inside the iris you can see fine lines radiating outward from the pupil, which is the kind of detail that AI-generated eyes consistently miss. The highlight reflection in the eye is slightly off-center and irregular, exactly how a real eye looks when lit from one side.
 
 [TECHNICAL]
-Primary activations center on the eye region and nasal bridge, which are typically the most diagnostic areas for authenticity. The activation map shows a relatively diffuse and low intensity pattern overall, which tends to correlate with genuine images where no single region triggers anomaly detection. Note that this analysis is based on visual artifacts detectable at this resolution, so highly compressed or low resolution images may reduce detection reliability.
+GradCAM activation peak: eye region (71%), secondary: nose bridge (38%).
+Activation pattern: diffuse, low-intensity — no single region dominated.
+EfficientNet-B4 real probability: 97%.
 
 [REGIONS]
-Eye and nose bridge region | The orange activation here shows the model examining the nasal bridge and inner eye corners, where the skin texture and lighting transition look completely natural and consistent with a real photograph.
+Eye and nose bridge region | The iris has natural variation in color from the centre outward, with thin irregular lines rather than a smooth gradient. The eyelid crease is slightly asymmetric, just like a real eyelid, and the skin just under the eye shows fine creases and texture rather than a polished surface.
+Hair | Looking at the full photo, individual strands are clearly visible along the edges of the hairline with slight variation in thickness and some fine strands catching the light differently. This is exactly how real hair looks in a photograph.
+Skin overall | The skin across the cheeks and forehead has visible pores and very slight uneven tone that looks natural. There are no areas that look unusually smooth or over-processed.
 
-EXAMPLE 3 - Borderline:
+EXAMPLE 3 - Borderline (hairline crop provided, also scanning full photo):
 [SUMMARY]
-This image shows mixed signals. The heatmap highlights some subtle inconsistencies around the hairline but they are not definitive enough to call with high confidence.
+The hairline looks slightly too neat to be natural, but at 61% the model is not certain and the rest of the face looks fairly normal.
 
 [DETAILED]
-The heatmap is lighting up mainly around the hairline and the top of the forehead, shown in yellow and light orange. If you look at those spots in the original image, the hair to skin transition looks slightly too clean, almost like it was placed rather than growing naturally. That said, the rest of the face looks fairly consistent and the model is only 61% confident it is fake, which is quite low. This could be a deepfake with a high quality generator, or it could simply be a photo with strong studio lighting that makes the hairline look artificially sharp.
+In the crop, the individual hairs at the hairline all end with the same sharpness rather than the irregular tapered tips you see in real hair. That said, heavy photo editing or studio lighting can sometimes create a similar effect, so this alone is not enough to be certain.
 
 [TECHNICAL]
-Activation intensity is relatively low across the board, with the highest response near the upper hairline boundary. This kind of diffuse low confidence pattern often appears with newer generation models that have improved blending, or with images where compression artifacts partially mask manipulation signals. The 61% fake probability sits close to the decision boundary so this result should be treated with caution.
+GradCAM activation peak: hairline (58%).
+Activation pattern: diffuse single-region, 61% probability — close to the boundary, result is uncertain.
+EfficientNet-B4 fake probability: 61%.
 
 [REGIONS]
-Forehead and hairline region | The yellow activation traces the hairline boundary, where the transition between hair and skin looks unusually sharp and uniform compared to what you would expect in a natural photograph.
+Forehead and hairline region | The hairs along the edge of the hairline all stop at the same level of sharpness, which is unusual because real hair has a lot of variation in how each strand ends. The skin just below the hairline is very smooth with no fine downy hairs visible.
+Eyes | Looking at the full photo, the eyes look natural with visible iris detail and slightly irregular reflections. Nothing here raises a red flag.
+Skin and cheeks | The skin on the cheeks has normal variation in tone and some texture visible in the highlights. This part of the face looks consistent with a real photograph.
 
-Now analyze the images you have been given and respond in the same style. \
-Use the [SUMMARY], [DETAILED], [TECHNICAL], [REGIONS] format exactly."""
+Now analyze the images you have been given. Follow the length rules exactly. \
+Use the [SUMMARY], [DETAILED], [TECHNICAL], [REGIONS] format."""
 
 
 SYSTEM_PROMPT_WITHOUT_GRADCAM = """You are a forensic image analyst explaining deepfake detection results \
@@ -117,6 +146,7 @@ SYSTEM_PROMPT = SYSTEM_PROMPT_WITH_GRADCAM
 def build_explanation_prompt(
     detection: DetectionContext,
     gradcam_available: bool = True,
+    region_count: int = 0,
 ) -> str:
     """
     Build the user-facing prompt with detection context and region labels.
@@ -142,12 +172,25 @@ def build_explanation_prompt(
     fake_prob = detection.probabilities.get("fake", 0)
     real_prob = detection.probabilities.get("real", 0)
 
+    # Build the image layout description so the VLM knows exactly which image is which
+    crop_image_start = 3 if gradcam_available else 2
     if gradcam_available:
-        image_instruction = (
-            "Look at the GradCAM heatmap (Image 2) and describe what you observe "
-            "in the highlighted regions of the original photo (Image 1). "
-            "What specific visual details in those regions support this classification?"
-        )
+        if region_count > 0:
+            crop_refs = ", ".join(
+                f"Image {crop_image_start + i}" for i in range(region_count)
+            )
+            image_instruction = (
+                f"Look at the GradCAM heatmap (Image 2) to see which areas the model focused on, "
+                f"then examine the zoomed-in region crops ({crop_refs}) to inspect each area up close. "
+                f"Describe the specific visual details you actually see in the crops — texture, edges, "
+                f"blending, skin quality — that support or contradict this classification."
+            )
+        else:
+            image_instruction = (
+                "Look at the GradCAM heatmap (Image 2) and describe what you observe "
+                "in the highlighted regions of the original photo (Image 1). "
+                "What specific visual details in those regions support this classification?"
+            )
     else:
         image_instruction = (
             "The GradCAM heatmap is not available for this analysis. "
@@ -158,27 +201,37 @@ def build_explanation_prompt(
     regions_instruction = ""
 
     if detection.region_categories:
-        # Enriched path: include category label + top-3 artifact hints per region
+        # Enriched path: include category label + artifact hints + crop image reference
         lines = []
-        for rc in detection.region_categories:
+        for i, rc in enumerate(detection.region_categories):
             hints = ", ".join(rc.common_artifacts[:3])
-            lines.append(f"- {rc.label} [Category: {rc.category_label} | Look for: {hints}]")
+            crop_ref = f"Image {crop_image_start + i}" if i < region_count else ""
+            crop_note = f" | Crop: {crop_ref}" if crop_ref else ""
+            lines.append(
+                f"- {rc.label} [Category: {rc.category_label} | Look for: {hints}{crop_note}]"
+            )
         labels_list = "\n".join(lines)
         regions_instruction = (
             f"\n\nThe following facial regions were highlighted by the model. "
-            f"Each entry includes a semantic category and known artifact types as guidance. "
-            f"In the [REGIONS] section, write one sentence for each explaining what you "
-            f"observe there — use the artifact hints to direct your eye, but describe what "
-            f"you actually see rather than repeating the hints verbatim:\n"
+            f"Each entry includes a semantic category, artifact guidance, and its crop image reference. "
+            f"In the [REGIONS] section write 2-3 sentences per region. Each sentence must describe "
+            f"something specific you can see in that crop — texture, edges, pores, gradients, "
+            f"reflections. Use the artifact hints to direct your eye but do not repeat them verbatim:\n"
             f"{labels_list}"
         )
     elif detection.region_labels:
         # Fallback path: plain labels with no category context
-        labels_list = "\n".join(f"- {label}" for label in detection.region_labels)
+        lines = []
+        for i, label in enumerate(detection.region_labels):
+            crop_ref = f"Image {crop_image_start + i}" if i < region_count else ""
+            crop_note = f" [{crop_ref}]" if crop_ref else ""
+            lines.append(f"- {label}{crop_note}")
+        labels_list = "\n".join(lines)
         regions_instruction = (
             f"\n\nThe following facial regions were highlighted by the model. "
-            f"In the [REGIONS] section, write one sentence for each explaining "
-            f"what you observe there and why the model may have focused on it:\n"
+            f"In the [REGIONS] section write 2-3 sentences per region describing specific visual "
+            f"details you observe in each crop — what does the skin, texture, edge, or boundary "
+            f"actually look like?\n"
             f"{labels_list}"
         )
 

--- a/backend/app/services/vlm/prompt_builder.py
+++ b/backend/app/services/vlm/prompt_builder.py
@@ -176,9 +176,7 @@ def build_explanation_prompt(
     crop_image_start = 3 if gradcam_available else 2
     if gradcam_available:
         if region_count > 0:
-            crop_refs = ", ".join(
-                f"Image {crop_image_start + i}" for i in range(region_count)
-            )
+            crop_refs = ", ".join(f"Image {crop_image_start + i}" for i in range(region_count))
             image_instruction = (
                 f"Look at the GradCAM heatmap (Image 2) to see which areas the model focused on, "
                 f"then examine the zoomed-in region crops ({crop_refs}) to inspect each area up close. "

--- a/backend/app/services/vlm/providers/anthropic.py
+++ b/backend/app/services/vlm/providers/anthropic.py
@@ -36,13 +36,19 @@ class AnthropicProvider(BaseVLMProvider):
         heatmap_bytes: bytes,
         detection: DetectionContext,
         gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         start_time = time.time()
+        regions = region_image_bytes or []
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
         )
-        user_prompt = build_explanation_prompt(detection, gradcam_available=gradcam_available)
+        user_prompt = build_explanation_prompt(
+            detection,
+            gradcam_available=gradcam_available,
+            region_count=len(regions),
+        )
 
         image_b64 = base64.b64encode(image_bytes).decode("utf-8")
 
@@ -65,6 +71,18 @@ class AnthropicProvider(BaseVLMProvider):
                         "type": "base64",
                         "media_type": "image/png",
                         "data": heatmap_b64,
+                    },
+                }
+            )
+        for region_bytes in regions:
+            region_b64 = base64.b64encode(region_bytes).decode("utf-8")
+            content.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": region_b64,
                     },
                 }
             )

--- a/backend/app/services/vlm/providers/gemini.py
+++ b/backend/app/services/vlm/providers/gemini.py
@@ -40,13 +40,19 @@ class GeminiProvider(BaseVLMProvider):
         heatmap_bytes: bytes,
         detection: DetectionContext,
         gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         start_time = time.time()
+        regions = region_image_bytes or []
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
         )
-        user_prompt = build_explanation_prompt(detection, gradcam_available=gradcam_available)
+        user_prompt = build_explanation_prompt(
+            detection,
+            gradcam_available=gradcam_available,
+            region_count=len(regions),
+        )
 
         try:
             contents = [
@@ -55,6 +61,8 @@ class GeminiProvider(BaseVLMProvider):
             ]
             if gradcam_available:
                 contents.append(types.Part.from_bytes(data=heatmap_bytes, mime_type="image/png"))
+            for region_bytes in regions:
+                contents.append(types.Part.from_bytes(data=region_bytes, mime_type="image/jpeg"))
 
             response = self._client.models.generate_content(
                 model=self._model,

--- a/backend/app/services/vlm/providers/mock.py
+++ b/backend/app/services/vlm/providers/mock.py
@@ -90,6 +90,8 @@ class MockProvider(BaseVLMProvider):
         image_bytes: bytes,
         heatmap_bytes: bytes,
         detection: DetectionContext,
+        gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         """Return a mock explanation based on the detection classification."""
 

--- a/backend/app/services/vlm/providers/openai.py
+++ b/backend/app/services/vlm/providers/openai.py
@@ -39,13 +39,19 @@ class OpenAIProvider(BaseVLMProvider):
         heatmap_bytes: bytes,
         detection: DetectionContext,
         gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
     ) -> VLMExplanation:
         start_time = time.time()
+        regions = region_image_bytes or []
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
         )
-        user_prompt = build_explanation_prompt(detection, gradcam_available=gradcam_available)
+        user_prompt = build_explanation_prompt(
+            detection,
+            gradcam_available=gradcam_available,
+            region_count=len(regions),
+        )
 
         image_b64 = base64.b64encode(image_bytes).decode("utf-8")
 
@@ -57,6 +63,11 @@ class OpenAIProvider(BaseVLMProvider):
             heatmap_b64 = base64.b64encode(heatmap_bytes).decode("utf-8")
             content.append(
                 {"type": "input_image", "image_url": f"data:image/png;base64,{heatmap_b64}"}
+            )
+        for region_bytes in regions:
+            region_b64 = base64.b64encode(region_bytes).decode("utf-8")
+            content.append(
+                {"type": "input_image", "image_url": f"data:image/jpeg;base64,{region_b64}"}
             )
 
         try:

--- a/backend/app/services/vlm/providers/rule_based.py
+++ b/backend/app/services/vlm/providers/rule_based.py
@@ -1,0 +1,427 @@
+"""
+Rule-Based Template Explanation Provider
+
+Generates structured, data-driven explanations from detection metadata alone —
+no API calls, no image inspection, zero cost.
+
+The key design principle is specificity: every sentence references a concrete
+number (activation score, confidence, region rank) from the actual detection
+result. Generic artifact lists are avoided; instead, one targeted artifact is
+selected per region based on the category and the relative activation level.
+
+Intended use:
+- User-study control condition: compare against VLM explanations to measure
+  whether visual AI reasoning adds value beyond structured numeric analysis.
+- Fallback when no VLM API key is configured.
+- Offline / cost-free operation.
+
+Research note: this provider is intentionally *different* from VLM, not a
+worse imitation. It offers transparent, reproducible, number-grounded
+reasoning. A VLM offers visually-grounded but opaque inference.
+"""
+
+import time
+
+from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInfo, VLMExplanation
+
+# ---------------------------------------------------------------------------
+# Activation pattern inference
+# ---------------------------------------------------------------------------
+
+def _infer_manipulation_type(regions: list) -> str:
+    """
+    Infer the likely manipulation type from the activation pattern across regions.
+
+    - Single dominant region (top activation >> rest) → localised edit / face-swap
+    - Multiple high-activation regions (top ~= second) → full-face generation (GAN/diffusion)
+    - No clear regions → ambiguous
+    """
+    if len(regions) == 0:
+        return "ambiguous"
+
+    scores = sorted([r.activation_score for r in regions], reverse=True)
+
+    if len(scores) == 1:
+        return "localised"
+
+    top, second = scores[0], scores[1]
+    ratio = top / second if second > 0 else float("inf")
+
+    if ratio >= 2.0:
+        return "localised"   # one region dominates strongly
+    if top >= 0.55 and second >= 0.45:
+        return "distributed"  # multiple strong regions → generative artefacts
+    return "ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Per-region artifact selection
+# ---------------------------------------------------------------------------
+
+# For each category, pick the single most discriminative artifact to mention.
+# Order matters: the first entry is used when confidence is high, the second
+# when confidence is moderate, so the language stays specific.
+_CATEGORY_PRIMARY_ARTIFACT: dict[str, list[str]] = {
+    "eyes_pupils": [
+        "asymmetric catchlight positioning",
+        "unnatural iris texture smoothness",
+    ],
+    "skin_texture": [
+        "pore-pattern discontinuity at the region boundary",
+        "overly uniform skin-tone distribution",
+    ],
+    "hair_hairline": [
+        "unnaturally smooth hairline-to-forehead transition",
+        "absence of fine stray hairs along the hairline",
+    ],
+    "nose_midface": [
+        "subtle geometric distortion around the nasal bridge",
+        "mid-face blending seam",
+    ],
+    "mouth_lips": [
+        "tooth-boundary sharpness inconsistency",
+        "lip-corner blending artefact",
+    ],
+    "jawline_chin": [
+        "face-to-neck boundary blending seam",
+        "jawline contour smoothing typical of face-swap composites",
+    ],
+}
+
+
+def _pick_artifact(category_id: str, confidence: float) -> str | None:
+    options = _CATEGORY_PRIMARY_ARTIFACT.get(category_id)
+    if not options:
+        return None
+    return options[0] if confidence >= 0.80 else options[1] if len(options) > 1 else options[0]
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+def _build_summary(detection: DetectionContext, top_region=None) -> str:
+    pct = round(detection.confidence * 100)
+    is_fake = detection.classification == "fake"
+
+    if is_fake:
+        if detection.confidence >= 0.85:
+            opening = (
+                f"The detection model classified this image as a deepfake with {pct}% confidence."
+            )
+        elif detection.confidence >= 0.65:
+            opening = (
+                f"The detection model flagged this image as likely manipulated ({pct}% confidence)."
+            )
+        else:
+            opening = (
+                f"The detection model returned a weak deepfake signal ({pct}% confidence). "
+                f"The result is uncertain."
+            )
+    else:
+        if detection.confidence >= 0.85:
+            opening = (
+                f"The detection model classified this image as authentic with {pct}% confidence."
+            )
+        elif detection.confidence >= 0.65:
+            opening = f"The detection model found no strong signs of manipulation ({pct}% confidence)."
+        else:
+            opening = (
+                f"The detection model returned a weak authenticity signal ({pct}% confidence). "
+                f"Minor editing or compression may be present."
+            )
+
+    if top_region is not None:
+        region_name = getattr(top_region, "category_label", None) or getattr(
+            top_region, "label", "an unidentified region"
+        )
+        act_pct = round(top_region.activation_score * 100)
+        return f"{opening} The strongest signal came from the {region_name} area ({act_pct}% activation)."
+
+    return opening
+
+
+# ---------------------------------------------------------------------------
+# Detailed analysis
+# ---------------------------------------------------------------------------
+
+def _build_detailed_analysis(detection: DetectionContext) -> str:
+    is_fake = detection.classification == "fake"
+    pct = round(detection.confidence * 100)
+    paragraphs: list[str] = []
+
+    regions = sorted(
+        detection.region_categories or [], key=lambda r: r.activation_score, reverse=True
+    )
+
+    # --- Opening: confidence + pattern inference ---
+    manipulation_type = _infer_manipulation_type(regions)
+
+    if is_fake:
+        if manipulation_type == "localised":
+            pattern_note = (
+                "The activation is concentrated in one dominant region, which is characteristic "
+                "of localised face-swap edits rather than fully AI-generated faces."
+            )
+        elif manipulation_type == "distributed":
+            pattern_note = (
+                "High activation is spread across multiple distinct regions simultaneously, "
+                "a pattern more typical of fully generative models (GANs or diffusion) "
+                "than targeted local edits."
+            )
+        else:
+            pattern_note = (
+                "The activation pattern did not clearly indicate a single manipulation type."
+            )
+
+        paragraphs.append(
+            f"The model assigned {pct}% probability to this image being manipulated. "
+            f"{pattern_note}"
+        )
+    else:
+        paragraphs.append(
+            f"The model assigned {pct}% probability to this image being authentic. "
+            f"The attention pattern showed no localised anomalies consistent with known "
+            f"deepfake manipulation signatures."
+        )
+
+    # --- Per-region paragraphs ---
+    if regions:
+        top_score = regions[0].activation_score
+
+        for i, region in enumerate(regions[:3]):
+            act_pct = round(region.activation_score * 100)
+            cat_label = region.category_label
+            region_label = region.label
+            artifact = _pick_artifact(region.category_id, detection.confidence)
+
+            if i == 0:
+                rank_phrase = "The highest-activation region"
+            elif i == 1:
+                ratio = round(top_score / region.activation_score, 1) if region.activation_score > 0 else "—"
+                rank_phrase = f"The second-ranked region ({ratio}× lower activation than the top)"
+            else:
+                rank_phrase = "A third region"
+
+            if is_fake:
+                if artifact:
+                    para = (
+                        f"{rank_phrase} was the **{cat_label}** ({region_label}) "
+                        f"with {act_pct}% activation. "
+                        f"At this confidence level, the most likely indicator in this area is "
+                        f"{artifact}."
+                    )
+                else:
+                    para = (
+                        f"{rank_phrase} was the **{cat_label}** ({region_label}) "
+                        f"with {act_pct}% activation, suggesting anomalies in this area."
+                    )
+            else:
+                if artifact:
+                    para = (
+                        f"{rank_phrase} was the **{cat_label}** ({region_label}) "
+                        f"with {act_pct}% activation. "
+                        f"No evidence of {artifact} was detected here."
+                    )
+                else:
+                    para = (
+                        f"{rank_phrase} was the **{cat_label}** ({region_label}) "
+                        f"with {act_pct}% activation — within the expected range for authentic imagery."
+                    )
+
+            paragraphs.append(para)
+
+    elif detection.region_labels:
+        label_list = ", ".join(detection.region_labels[:3])
+        if is_fake:
+            paragraphs.append(
+                f"The model's attention was distributed across: {label_list}. "
+                f"These regions exhibited activation patterns inconsistent with unmanipulated photographs."
+            )
+        else:
+            paragraphs.append(
+                f"The model examined: {label_list}. "
+                f"None showed activation patterns indicative of manipulation."
+            )
+
+    # --- Closing ---
+    if is_fake:
+        paragraphs.append(
+            "This analysis is based on the model's internal spatial attention and reflects "
+            "where in the image the detection signal is strongest. It does not constitute "
+            "a pixel-level forensic inspection."
+        )
+    else:
+        paragraphs.append(
+            "The absence of localised high-activation anomalies supports the authenticity "
+            "classification. Note that sophisticated manipulations targeting regions outside "
+            "the model's attention may not be detected."
+        )
+
+    return "\n\n".join(paragraphs)
+
+
+# ---------------------------------------------------------------------------
+# Per-region comments  (label → one-sentence explanation)
+# ---------------------------------------------------------------------------
+
+def _build_region_comments(detection: DetectionContext) -> dict[str, str]:
+    """Return one focused sentence per region, keyed by region label.
+
+    These are attached to evidence_regions[].explanation in the API response
+    and displayed directly in the region cards on the frontend.
+    """
+    is_fake = detection.classification == "fake"
+    regions = sorted(
+        detection.region_categories or [], key=lambda r: r.activation_score, reverse=True
+    )
+
+    comments: dict[str, str] = {}
+    for region in regions[:3]:
+        act_pct = round(region.activation_score * 100)
+        artifact = _pick_artifact(region.category_id, detection.confidence)
+
+        if is_fake:
+            if artifact:
+                sentence = (
+                    f"The model's attention ({act_pct}% activation) in this area is consistent "
+                    f"with {artifact}, a known indicator in the {region.category_label} region."
+                )
+            else:
+                sentence = (
+                    f"This region drew {act_pct}% activation, suggesting the model detected "
+                    f"anomalies in the {region.category_label} area."
+                )
+        else:
+            if artifact:
+                sentence = (
+                    f"This region showed {act_pct}% activation and appeared natural — "
+                    f"no evidence of {artifact} was detected in the {region.category_label} area."
+                )
+            else:
+                sentence = (
+                    f"With {act_pct}% activation, this {region.category_label} region "
+                    f"showed no anomalies consistent with manipulation."
+                )
+
+        comments[region.label] = sentence
+
+    return comments
+
+
+# ---------------------------------------------------------------------------
+# Technical notes
+# ---------------------------------------------------------------------------
+
+def _build_technical_notes(detection: DetectionContext) -> str:
+    fake_pct = round(detection.probabilities.get("fake", 0) * 100, 1)
+    real_pct = round(detection.probabilities.get("real", 0) * 100, 1)
+    log_odds = None
+    p_fake = detection.probabilities.get("fake", 0)
+    if 0 < p_fake < 1:
+        import math
+        log_odds = round(math.log(p_fake / (1 - p_fake)), 3)
+
+    regions = sorted(
+        detection.region_categories or [], key=lambda r: r.activation_score, reverse=True
+    )
+
+    lines = [
+        f"Architecture: {detection.model_used}",
+        f"Softmax output — P(fake): {fake_pct}%, P(real): {real_pct}%"
+        + (f"  |  log-odds: {log_odds:+.3f}" if log_odds is not None else ""),
+    ]
+
+    if regions:
+        region_summary = "; ".join(
+            f"{r.category_label} α={round(r.activation_score, 3)}" for r in regions[:3]
+        )
+        lines.append(f"GradCAM spatial attention (α, mean activation per region): {region_summary}")
+
+        manipulation_type = _infer_manipulation_type(regions)
+        pattern_descriptions = {
+            "localised": "localised edit / face-swap composite (single-region dominance, α-ratio ≥ 2.0)",
+            "distributed": "full-face generative synthesis (multi-region co-activation, GANs or diffusion)",
+            "ambiguous": "ambiguous — insufficient spatial separation to classify manipulation modality",
+        }
+        lines.append(
+            f"Inferred manipulation modality: {pattern_descriptions.get(manipulation_type, manipulation_type)}"
+        )
+
+        if len(regions) >= 2:
+            ratio = round(regions[0].activation_score / regions[1].activation_score, 2) if regions[1].activation_score > 0 else float("inf")
+            lines.append(
+                f"Activation dominance ratio (rank-1 / rank-2): {ratio:.2f}"
+            )
+
+    lines.append(
+        "Saliency method: Gradient-weighted Class Activation Mapping (GradCAM) "
+        "on final convolutional feature map of EfficientNet-B4."
+    )
+    lines.append(
+        "Explanation pipeline: deterministic rule-based inference — "
+        "no vision-language model invoked. Output is fully reproducible given identical inputs."
+    )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+class RuleBasedProvider(BaseVLMProvider):
+    """
+    Deterministic, data-driven explanation provider.
+
+    Every statement is grounded in a concrete number from the detection result.
+    Output is fully reproducible: same input → same explanation.
+    """
+
+    async def generate_explanation(
+        self,
+        image_bytes: bytes,
+        heatmap_bytes: bytes,
+        detection: DetectionContext,
+        gradcam_available: bool = True,
+        region_image_bytes: list[bytes] | None = None,
+    ) -> VLMExplanation:
+        start = time.time()
+
+        regions = sorted(
+            detection.region_categories or [], key=lambda r: r.activation_score, reverse=True
+        )
+        top_region = regions[0] if regions else None
+
+        summary = _build_summary(detection, top_region)
+        detailed = _build_detailed_analysis(detection)
+        notes = _build_technical_notes(detection)
+        region_comments = _build_region_comments(detection)
+
+        return VLMExplanation(
+            summary=summary,
+            detailed_analysis=detailed,
+            technical_notes=notes,
+            region_comments=region_comments if region_comments else None,
+            provider="rule_based",
+            model="rule-based-v1",
+            processing_time_ms=int((time.time() - start) * 1000),
+            estimated_cost_usd=0.0,
+            input_tokens=0,
+            output_tokens=0,
+            raw_response=None,
+        )
+
+    def get_provider_info(self) -> ProviderInfo:
+        return ProviderInfo(
+            id="rule_based",
+            name="Rule-Based Templates",
+            model="rule-based-v1",
+            available=True,
+            latency_estimate_ms=1,
+            cost_per_1m_input_tokens=0.0,
+            cost_per_1m_output_tokens=0.0,
+        )
+
+    def estimate_cost(self, input_tokens: int, output_tokens: int) -> float:
+        return 0.0

--- a/backend/app/services/vlm/providers/rule_based.py
+++ b/backend/app/services/vlm/providers/rule_based.py
@@ -28,6 +28,7 @@ from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInf
 # Activation pattern inference
 # ---------------------------------------------------------------------------
 
+
 def _infer_manipulation_type(regions: list) -> str:
     """
     Infer the likely manipulation type from the activation pattern across regions.
@@ -48,7 +49,7 @@ def _infer_manipulation_type(regions: list) -> str:
     ratio = top / second if second > 0 else float("inf")
 
     if ratio >= 2.0:
-        return "localised"   # one region dominates strongly
+        return "localised"  # one region dominates strongly
     if top >= 0.55 and second >= 0.45:
         return "distributed"  # multiple strong regions → generative artefacts
     return "ambiguous"
@@ -100,6 +101,7 @@ def _pick_artifact(category_id: str, confidence: float) -> str | None:
 # Summary
 # ---------------------------------------------------------------------------
 
+
 def _build_summary(detection: DetectionContext, top_region=None) -> str:
     pct = round(detection.confidence * 100)
     is_fake = detection.classification == "fake"
@@ -124,7 +126,9 @@ def _build_summary(detection: DetectionContext, top_region=None) -> str:
                 f"The detection model classified this image as authentic with {pct}% confidence."
             )
         elif detection.confidence >= 0.65:
-            opening = f"The detection model found no strong signs of manipulation ({pct}% confidence)."
+            opening = (
+                f"The detection model found no strong signs of manipulation ({pct}% confidence)."
+            )
         else:
             opening = (
                 f"The detection model returned a weak authenticity signal ({pct}% confidence). "
@@ -144,6 +148,7 @@ def _build_summary(detection: DetectionContext, top_region=None) -> str:
 # ---------------------------------------------------------------------------
 # Detailed analysis
 # ---------------------------------------------------------------------------
+
 
 def _build_detailed_analysis(detection: DetectionContext) -> str:
     is_fake = detection.classification == "fake"
@@ -175,8 +180,7 @@ def _build_detailed_analysis(detection: DetectionContext) -> str:
             )
 
         paragraphs.append(
-            f"The model assigned {pct}% probability to this image being manipulated. "
-            f"{pattern_note}"
+            f"The model assigned {pct}% probability to this image being manipulated. {pattern_note}"
         )
     else:
         paragraphs.append(
@@ -198,7 +202,11 @@ def _build_detailed_analysis(detection: DetectionContext) -> str:
             if i == 0:
                 rank_phrase = "The highest-activation region"
             elif i == 1:
-                ratio = round(top_score / region.activation_score, 1) if region.activation_score > 0 else "—"
+                ratio = (
+                    round(top_score / region.activation_score, 1)
+                    if region.activation_score > 0
+                    else "—"
+                )
                 rank_phrase = f"The second-ranked region ({ratio}× lower activation than the top)"
             else:
                 rank_phrase = "A third region"
@@ -265,6 +273,7 @@ def _build_detailed_analysis(detection: DetectionContext) -> str:
 # Per-region comments  (label → one-sentence explanation)
 # ---------------------------------------------------------------------------
 
+
 def _build_region_comments(detection: DetectionContext) -> dict[str, str]:
     """Return one focused sentence per region, keyed by region label.
 
@@ -313,6 +322,7 @@ def _build_region_comments(detection: DetectionContext) -> dict[str, str]:
 # Technical notes
 # ---------------------------------------------------------------------------
 
+
 def _build_technical_notes(detection: DetectionContext) -> str:
     fake_pct = round(detection.probabilities.get("fake", 0) * 100, 1)
     real_pct = round(detection.probabilities.get("real", 0) * 100, 1)
@@ -320,6 +330,7 @@ def _build_technical_notes(detection: DetectionContext) -> str:
     p_fake = detection.probabilities.get("fake", 0)
     if 0 < p_fake < 1:
         import math
+
         log_odds = round(math.log(p_fake / (1 - p_fake)), 3)
 
     regions = sorted(
@@ -349,10 +360,12 @@ def _build_technical_notes(detection: DetectionContext) -> str:
         )
 
         if len(regions) >= 2:
-            ratio = round(regions[0].activation_score / regions[1].activation_score, 2) if regions[1].activation_score > 0 else float("inf")
-            lines.append(
-                f"Activation dominance ratio (rank-1 / rank-2): {ratio:.2f}"
+            ratio = (
+                round(regions[0].activation_score / regions[1].activation_score, 2)
+                if regions[1].activation_score > 0
+                else float("inf")
             )
+            lines.append(f"Activation dominance ratio (rank-1 / rank-2): {ratio:.2f}")
 
     lines.append(
         "Saliency method: Gradient-weighted Class Activation Mapping (GradCAM) "
@@ -369,6 +382,7 @@ def _build_technical_notes(detection: DetectionContext) -> str:
 # ---------------------------------------------------------------------------
 # Provider
 # ---------------------------------------------------------------------------
+
 
 class RuleBasedProvider(BaseVLMProvider):
     """

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -36,6 +36,7 @@ import {
   type ImageRecord,
   type ApiError,
   type ApiMode,
+  type ExplanationResult,
 } from '@/lib/api';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import AuthPage from '@/components/auth/AuthPage';
@@ -187,19 +188,25 @@ function DevToolbar({
           <div>
             <p className="mb-1.5 text-xs font-medium text-xade-charcoal/70">VLM Provider</p>
             <div className="grid grid-cols-2 gap-1.5">
-              {(['openai', 'google', 'mock', 'none'] as const).map((provider) => (
+              {(
+                [
+                  { id: 'openai', label: 'OpenAI' },
+                  { id: 'google', label: 'Google' },
+                  { id: 'rule_based', label: 'Rule-Based' },
+                  { id: 'mock', label: 'Mock' },
+                  { id: 'none', label: 'None' },
+                ] as const
+              ).map(({ id, label }) => (
                 <button
-                  key={provider}
-                  onClick={() => onVlmProviderChange(provider)}
+                  key={id}
+                  onClick={() => onVlmProviderChange(id)}
                   className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
-                    vlmProvider === provider
+                    vlmProvider === id
                       ? 'bg-xade-blue text-white'
                       : 'bg-xade-charcoal/5 text-xade-charcoal/60 hover:bg-xade-charcoal/10'
                   }`}
                 >
-                  {provider === 'none'
-                    ? 'None'
-                    : provider.charAt(0).toUpperCase() + provider.slice(1)}
+                  {label}
                 </button>
               ))}
             </div>
@@ -928,7 +935,15 @@ function Lightbox({ src, onClose }: { src: string; onClose: () => void }) {
   );
 }
 
-function TechnicalDetails({ result, isFake }: { result: DetectionResult; isFake: boolean }) {
+function TechnicalDetails({
+  result,
+  isFake,
+  explanation,
+}: {
+  result: DetectionResult;
+  isFake: boolean;
+  explanation: ExplanationResult | null;
+}) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -997,13 +1012,22 @@ function TechnicalDetails({ result, isFake }: { result: DetectionResult; isFake:
             </div>
           )}
 
-          {result.explanation?.technical_notes && (
+          {explanation?.detailed_analysis && (
+            <div className="mt-4 border-t border-xade-charcoal/10 pt-4">
+              <p className="text-xs uppercase tracking-wide text-xade-charcoal/40">Full Analysis</p>
+              <p className="mt-2 text-sm leading-relaxed text-xade-charcoal/70">
+                {explanation.detailed_analysis}
+              </p>
+            </div>
+          )}
+
+          {explanation?.technical_notes && (
             <div className="mt-4 border-t border-xade-charcoal/10 pt-4">
               <p className="text-xs uppercase tracking-wide text-xade-charcoal/40">
                 Technical Notes
               </p>
               <p className="mt-2 text-sm leading-relaxed text-xade-charcoal/70">
-                {result.explanation.technical_notes}
+                {explanation.technical_notes}
               </p>
             </div>
           )}
@@ -1040,62 +1064,42 @@ function ResultView({ result, previewUrl, onBack }: ResultViewProps) {
         Back
       </button>
 
-      {/* Top row: Verdict + Summary */}
-      <div className="mb-4 grid grid-cols-2 gap-4">
-        {/* Verdict */}
-        <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white p-6">
-          <p
-            className={`text-[11px] font-semibold uppercase tracking-widest ${isFake ? 'text-red-400' : 'text-emerald-500'}`}
-          >
-            {isFake ? 'Deepfake detected' : 'Authentic'}
-          </p>
-          <p
-            className={`mt-1 text-6xl font-bold tabular-nums leading-none ${isFake ? 'text-red-500' : 'text-emerald-500'}`}
-          >
-            {confidencePct}%
-          </p>
-          <p className="mt-1 text-sm text-xade-charcoal/40">confidence</p>
-          <div className="mt-5">
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-xade-charcoal/8">
+      {/* Row 1: Verdict */}
+      <div className="mb-4 rounded-2xl border border-black/[0.06] bg-white p-6">
+        <div className="flex items-center gap-8">
+          <div className="shrink-0">
+            <p
+              className={`text-[11px] font-semibold uppercase tracking-widest ${isFake ? 'text-red-400' : 'text-emerald-500'}`}
+            >
+              {isFake ? 'Deepfake detected' : 'Authentic'}
+            </p>
+            <p
+              className={`mt-0.5 text-6xl font-bold tabular-nums leading-none ${isFake ? 'text-red-500' : 'text-emerald-500'}`}
+            >
+              {confidencePct}%
+            </p>
+            <p className="mt-1 text-sm text-xade-charcoal/40">confidence</p>
+          </div>
+          <div className="flex-1">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-xade-charcoal/8">
               <div
                 className={`h-full rounded-full ${isFake ? 'bg-red-400' : 'bg-emerald-400'}`}
                 style={{ width: `${fakePct}%` }}
               />
             </div>
-            <div className="mt-2 flex justify-between text-xs text-xade-charcoal/35">
+            <div className="mt-1.5 flex justify-between text-xs text-xade-charcoal/35">
               <span>{fakePct}% fake</span>
               <span>{realPct}% real</span>
             </div>
           </div>
         </div>
-
-        {/* Summary */}
-        <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white p-6">
-          <p className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
-            Summary
-          </p>
-          {explanation ? (
-            <>
-              <p className="flex-1 text-sm leading-relaxed text-xade-charcoal/70">
-                {explanation.summary}
-              </p>
-              <p className="mt-4 text-xs text-xade-charcoal/30">
-                {explanation.model} · {(explanation.processing_time_ms / 1000).toFixed(1)}s
-              </p>
-            </>
-          ) : (
-            <p className="text-sm text-xade-charcoal/35">
-              No explanation available. Select a VLM provider in dev settings.
-            </p>
-          )}
-        </div>
       </div>
 
-      {/* Middle row: Visual Analysis + Analysis */}
+      {/* Row 2: Images + explanation side by side */}
       <div className="mb-4 grid grid-cols-2 items-stretch gap-4">
-        {/* Visual Analysis */}
-        <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white p-6">
-          <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
+        {/* Images */}
+        <div className="rounded-2xl border border-black/[0.06] bg-white p-5">
+          <p className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
             Visual Analysis
           </p>
           <div className="grid grid-cols-2 gap-3">
@@ -1125,7 +1129,7 @@ function ResultView({ result, previewUrl, onBack }: ResultViewProps) {
             <div>
               <p className="mb-1.5 text-xs text-xade-charcoal/40">
                 Heatmap
-                <span className="ml-1 text-xade-charcoal/25">· red = high focus</span>
+                <span className="ml-1 text-xade-charcoal/25">· red = focus</span>
               </p>
               {result.gradcam_heatmap_url ? (
                 <div
@@ -1154,108 +1158,117 @@ function ResultView({ result, previewUrl, onBack }: ResultViewProps) {
           </div>
         </div>
 
-        {/* Analysis */}
-        <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white p-6">
+        {/* Explanation — merged summary + detailed */}
+        <div className="flex flex-col rounded-2xl border border-black/[0.06] bg-white p-5">
           <p className="mb-3 text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
-            Analysis
+            Explanation
           </p>
           {explanation ? (
-            <p className="text-sm leading-relaxed text-xade-charcoal/70">
-              {explanation.detailed_analysis}
+            <p className="flex-1 text-sm leading-relaxed text-xade-charcoal/70">
+              {explanation.summary}
+              {explanation.detailed_analysis ? ' ' + explanation.detailed_analysis : ''}
             </p>
           ) : (
             <p className="text-sm text-xade-charcoal/35">
-              Detailed analysis is not available. Enable a VLM provider in dev settings.
+              No explanation available. Select a VLM provider in dev settings.
             </p>
           )}
         </div>
       </div>
 
-      {/* Region Analysis */}
-      <div className="mb-4 rounded-2xl border border-black/[0.06] bg-white p-6">
-        <div className="mb-5 flex items-baseline justify-between">
-          <p className="text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
-            Region Analysis
-          </p>
-          {result.evidence_regions && result.evidence_regions.length > 0 && (
+      {/* Row 3: Facial Regions — stacked list */}
+      {result.evidence_regions && result.evidence_regions.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-black/[0.06] bg-white p-6">
+          <div className="mb-4 flex items-baseline justify-between">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-xade-charcoal/40">
+              Facial Regions
+            </p>
             <span className="text-xs text-xade-charcoal/30">
-              Top {Math.min(result.evidence_regions.length, 3)} by activation
+              {Math.min(result.evidence_regions.length, 3)} regions · by activation
             </span>
-          )}
-        </div>
-        {result.evidence_regions && result.evidence_regions.length > 0 ? (
+          </div>
+
           <div className="flex flex-col divide-y divide-black/[0.04]">
-            {result.evidence_regions.slice(0, 3).map((region, idx) => (
-              <div key={idx} className="flex items-start gap-4 py-4 first:pt-0 last:pb-0">
-                {/* Crop thumbnail */}
-                <div
-                  className="h-16 w-16 shrink-0 cursor-zoom-in overflow-hidden rounded-lg"
-                  onClick={() => setLightboxSrc(region.url)}
-                >
-                  <img
-                    src={region.url}
-                    alt={region.label}
-                    className="h-full w-full object-cover transition-opacity hover:opacity-75"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = 'none';
-                    }}
-                  />
-                </div>
+            {result.evidence_regions.slice(0, 3).map((region, idx) => {
+              const actPct = Math.round(region.activation_score * 100);
+              const suspicious = isFake && region.activation_score > 0.5;
+              const verdictLabel = isFake
+                ? region.activation_score > 0.5
+                  ? 'Suspicious'
+                  : 'Low signal'
+                : 'Looks natural';
+              const verdictStyle = suspicious
+                ? 'bg-red-50 text-red-500'
+                : isFake
+                  ? 'bg-orange-50 text-orange-400'
+                  : 'bg-emerald-50 text-emerald-600';
 
-                {/* Content */}
-                <div className="flex flex-1 flex-col gap-1">
-                  <div className="flex items-center gap-2">
-                    {region.category_label && (
-                      <span className="rounded-full bg-xade-blue/8 px-2 py-0.5 text-[11px] font-medium text-xade-blue">
-                        {region.category_label}
-                      </span>
-                    )}
-                    <span className="text-sm font-medium text-xade-charcoal/80">
-                      {region.label}
-                    </span>
-                  </div>
-
-                  {region.explanation && (
-                    <p className="text-xs leading-relaxed text-xade-charcoal/55">
-                      {region.explanation}
-                    </p>
-                  )}
-
-                  {region.common_artifacts && region.common_artifacts.length > 0 && (
-                    <div className="mt-1 flex flex-wrap gap-1">
-                      {region.common_artifacts.map((artifact, i) => (
-                        <span
-                          key={i}
-                          className="rounded-full bg-xade-charcoal/5 px-2 py-0.5 text-[11px] text-xade-charcoal/45"
-                        >
-                          {artifact}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Activation */}
-                <div className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
-                  <span className="text-sm font-semibold tabular-nums text-xade-charcoal/60">
-                    {Math.round(region.activation_score * 100)}%
-                  </span>
-                  <div className="h-1 w-14 overflow-hidden rounded-full bg-xade-charcoal/10">
-                    <div
-                      className="h-full rounded-full bg-xade-charcoal/25"
-                      style={{ width: `${Math.round(region.activation_score * 100)}%` }}
+              return (
+                <div key={idx} className="flex items-start gap-4 py-4 first:pt-0 last:pb-0">
+                  {/* Zoomed crop */}
+                  <div
+                    className="h-24 w-24 shrink-0 cursor-zoom-in overflow-hidden rounded-xl border border-black/[0.06]"
+                    onClick={() => setLightboxSrc(region.url)}
+                  >
+                    <img
+                      src={region.url}
+                      alt={region.label}
+                      className="h-full w-full object-cover transition-opacity hover:opacity-75"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = 'none';
+                      }}
                     />
                   </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-xade-charcoal/35">No high-activation regions detected.</p>
-        )}
-      </div>
 
-      <TechnicalDetails result={result} isFake={isFake} />
+                  {/* Content */}
+                  <div className="flex flex-1 flex-col gap-1.5">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {region.category_label && (
+                        <span className="rounded-full bg-xade-blue/8 px-2 py-0.5 text-[11px] font-medium text-xade-blue">
+                          {region.category_label}
+                        </span>
+                      )}
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${verdictStyle}`}
+                      >
+                        {verdictLabel}
+                      </span>
+                    </div>
+
+                    <p className="text-sm font-medium text-xade-charcoal/80">{region.label}</p>
+
+                    {region.explanation ? (
+                      <p className="text-xs leading-relaxed text-xade-charcoal/60">
+                        {region.explanation}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-xade-charcoal/35">
+                        No region-level explanation available.
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Activation */}
+                  <div className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
+                    <span className="text-sm font-semibold tabular-nums text-xade-charcoal/60">
+                      {actPct}%
+                    </span>
+                    <div className="h-1 w-16 overflow-hidden rounded-full bg-xade-charcoal/8">
+                      <div
+                        className={`h-full rounded-full ${suspicious ? 'bg-red-400' : 'bg-xade-charcoal/20'}`}
+                        style={{ width: `${actPct}%` }}
+                      />
+                    </div>
+                    <span className="text-[10px] text-xade-charcoal/30">activation</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <TechnicalDetails result={result} isFake={isFake} explanation={explanation} />
     </div>
   );
 }
@@ -1277,9 +1290,8 @@ function AuthenticatedApp() {
   const [selectedAnalysisId, setSelectedAnalysisId] = useState<string | null>(null);
   const [historyLoading, setHistoryLoading] = useState(true);
 
-  function loadHistory(userId: string) {
-    console.log('[XADE] loadHistory for user:', userId);
-    setHistoryLoading(true);
+  function loadHistory(userId: string, showLoading = false) {
+    if (showLoading) setHistoryLoading(true);
     Promise.all([
       fetchUserAnalyses(userId).then(setAnalyses),
       fetchUserImages(userId).then((images) => {
@@ -1295,7 +1307,7 @@ function AuthenticatedApp() {
   }
 
   useEffect(() => {
-    if (user?.id) loadHistory(user.id);
+    if (user?.id) loadHistory(user.id, true);
     else setHistoryLoading(false);
   }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1305,6 +1317,7 @@ function AuthenticatedApp() {
     setSelectedAnalysisId(null);
     setBackToView('upload');
     setView('result');
+    // Refresh history in background without clearing the existing list
     if (user?.id) loadHistory(user.id);
   }
 
@@ -1355,7 +1368,7 @@ function AuthenticatedApp() {
             loading={historyLoading}
             onNewAnalysis={handleNewAnalysis}
             onSelectAnalysis={handleSelectAnalysis}
-            onRefresh={() => user?.id && loadHistory(user.id)}
+            onRefresh={() => user?.id && loadHistory(user.id, true)}
           />
         ) : view === 'statistics' ? (
           <StatisticsView analyses={analyses} loading={historyLoading} />


### PR DESCRIPTION
Introduces a rule-based explanation provider for control-condition studies alongside several pipeline upgrades that make VLM explanations more grounded.

- VLM providers now receive zoomed-in region crops as separate images so they can inspect each GradCAM-highlighted area up close instead of inferring from the full photo. Threaded through base/factory/all providers.
- GradCAM masks activations outside the detected face bbox, preventing background regions from polluting evidence selection.
- Migrated face analysis from the legacy FaceMesh solution to the MediaPipe Tasks FaceLandmarker API. Dockerfile auto-downloads the float16 model; local dev downloads it on first run.
- Added rule_based provider that produces deterministic, number-grounded explanations from detection metadata alone (zero cost, no API calls). Registered in factory and listed as an available provider.
- Prompt builder enriched with region count + crop references so the VLM knows which image corresponds to which region.
- Result UI updated to surface per-region crops and explanations.