### PR TITLE
feat: LayerCAM with multi-layer fusion and face-bbox masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,9 @@ results/*.json
 # Accidental nested backend folder
 backend/backend/
 node_modules/.package-lock.json
+
+# Reproducible CAM comparison artifacts (regenerate with backend/scripts/compare_cams.py)
+backend/tests/fixtures/cam_comparison/*.png
+
+# Planning docs — kept locally, not tracked
+docs/vlm-grounding-roadmap.md

--- a/backend/app/routers/analyses.py
+++ b/backend/app/routers/analyses.py
@@ -132,7 +132,26 @@ def _run_gradcam(
         )
 
         generator = GradCAMGenerator(model)
-        heatmap = generator.generate(image_tensor, target_class=target_class)
+
+        # face_bbox is in original-image coordinates; GradCAMGenerator.generate
+        # applies the mask at image_tensor resolution, so scale it down.
+        tensor_face_bbox: tuple[int, int, int, int] | None = None
+        if face_bbox is not None:
+            orig_w, orig_h = image.size
+            _, _, th, tw = image_tensor.shape
+            fx1, fy1, fx2, fy2 = face_bbox
+            tensor_face_bbox = (
+                int(fx1 * tw / orig_w),
+                int(fy1 * th / orig_h),
+                int(fx2 * tw / orig_w),
+                int(fy2 * th / orig_h),
+            )
+
+        heatmap = generator.generate(
+            image_tensor,
+            target_class=target_class,
+            face_bbox=tensor_face_bbox,
+        )
         overlay = generator.create_overlay(image, heatmap)
 
         filepath = save_heatmap_locally(overlay)

--- a/backend/app/services/gradcam_service.py
+++ b/backend/app/services/gradcam_service.py
@@ -1,13 +1,23 @@
 """
-GradCAM (Gradient-weighted Class Activation Mapping) service for XADE.
+Class Activation Mapping service for XADE.
 
 Generates heatmaps that visualize which facial regions the deepfake detection
 model focused on, enabling grounded VLM explanations.
+
+CAM method is selected by the `CAM_METHOD` environment variable:
+  - `layercam` (default) — multi-layer LayerCAM fused over the last two conv
+    stages of EfficientNet-B4. Sharper localization than vanilla Grad-CAM.
+  - `gradcam` — classic Grad-CAM on the final conv block. Kept as a
+    reproducible baseline for thesis ablation.
+
+Both paths use jacobgil/pytorch-grad-cam (MIT/Apache-2.0) so output shapes
+and normalization conventions are identical across methods.
 """
 
 from __future__ import annotations
 
 # stdlib
+import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -17,11 +27,15 @@ import numpy as np
 import torch
 import torch.nn as nn
 from PIL import Image
+from pytorch_grad_cam import GradCAM, LayerCAM
+from pytorch_grad_cam.utils.model_targets import ClassifierOutputTarget
+
+CAM_METHOD = os.getenv("CAM_METHOD", "layercam").lower()
 
 
 @dataclass
 class RegionMetadata:
-    """Metadata about activated regions in the GradCAM heatmap."""
+    """Metadata about activated regions in the CAM heatmap."""
 
     centroid_x: float  # Normalized [0, 1] — horizontal center of mass
     centroid_y: float  # Normalized [0, 1] — vertical center of mass
@@ -32,57 +46,58 @@ class RegionMetadata:
 
 class GradCAMGenerator:
     """
-    Generates GradCAM heatmaps for a DeepfakeDetector model.
+    Generates class activation heatmaps for a DeepfakeDetector model.
 
-    Uses PyTorch forward/backward hooks on the last convolutional block of
-    EfficientNet-B4 (`model.model.features[-1]`).
+    Default method is LayerCAM (Jiang et al., 2021) fused over
+    `model.model.features[-2]` and `model.model.features[-1]`. The final
+    conv block alone gives 7×7 blobs at a 224² input; fusing the preceding
+    stage reduces that bleed. Set `CAM_METHOD=gradcam` to fall back to
+    classic Grad-CAM on the final block for baseline comparisons.
 
     Usage:
         generator = GradCAMGenerator(model)
-        heatmap = generator.generate(image_tensor, target_class=0)
+        heatmap = generator.generate(image_tensor, target_class=0, face_bbox=bbox)
         overlay = generator.create_overlay(original_image, heatmap)
         metadata = generator.extract_region_metadata(heatmap)
         regions = generator.extract_evidence_regions(original_image, heatmap)
     """
 
-    def __init__(self, model: nn.Module) -> None:
+    def __init__(self, model: nn.Module, method: Optional[str] = None) -> None:
         self.model = model
-        self._target_layer = model.model.features[-1]
-        self._activations: Optional[torch.Tensor] = None
-        self._gradients: Optional[torch.Tensor] = None
-        self._hooks: list = []
+        self.method = (method or CAM_METHOD).lower()
 
-    def _register_hooks(self) -> None:
-        """Register forward and backward hooks on the target layer."""
+        if self.method == "gradcam":
+            target_layers = [model.model.features[-1]]
+            self._cam = GradCAM(model=model, target_layers=target_layers)
+        else:
+            target_layers = [model.model.features[-2], model.model.features[-1]]
+            self._cam = LayerCAM(model=model, target_layers=target_layers)
+            self.method = "layercam"
 
-        def forward_hook(module: nn.Module, input: tuple, output: torch.Tensor) -> None:
-            self._activations = output.detach()
-
-        def backward_hook(module: nn.Module, grad_input: tuple, grad_output: tuple) -> None:
-            self._gradients = grad_output[0].detach()
-
-        self._hooks.append(self._target_layer.register_forward_hook(forward_hook))
-        self._hooks.append(self._target_layer.register_full_backward_hook(backward_hook))
-
-    def _remove_hooks(self) -> None:
-        """Remove all registered hooks to prevent memory leaks."""
-        for hook in self._hooks:
-            hook.remove()
-        self._hooks.clear()
+        self._target_layers = target_layers
 
     def generate(
         self,
         image_tensor: torch.Tensor,
         target_class: Optional[int] = None,
+        face_bbox: Optional[tuple[int, int, int, int]] = None,
     ) -> np.ndarray:
         """
-        Generate a GradCAM heatmap for the given image tensor.
+        Generate a CAM heatmap for the given image tensor.
+
+        When `face_bbox` is provided, the raw CAM is masked to the face
+        region **before** max-normalization so that background activations
+        cannot dominate the scale. The returned heatmap is therefore always
+        normalized to [0, 1] within the face (peak == 1.0 inside the bbox).
 
         Args:
             image_tensor: Preprocessed image tensor of shape (1, C, H, W).
                           Must already be on the correct device.
             target_class: Class index to generate heatmap for.
                           If None, uses the predicted class (argmax).
+            face_bbox: Optional (x1, y1, x2, y2) in image-tensor pixel
+                       coordinates. Activations outside this box are zeroed
+                       before normalization.
 
         Returns:
             Normalized heatmap as a float32 numpy array of shape (H, W)
@@ -91,45 +106,32 @@ class GradCAMGenerator:
         was_training = self.model.training
         self.model.eval()
 
-        self._register_hooks()
-
         try:
-            image_tensor = image_tensor.requires_grad_(False)
-
-            outputs = self.model(image_tensor)
-
             if target_class is None:
+                with torch.no_grad():
+                    outputs = self.model(image_tensor)
                 target_class = int(outputs.argmax(dim=1).item())
 
-            self.model.zero_grad()
+            targets = [ClassifierOutputTarget(target_class)]
+            # BaseCAM resizes to input spatial size and returns float32 [0,1]
+            cam = self._cam(input_tensor=image_tensor, targets=targets)[0]
 
-            one_hot = torch.zeros_like(outputs)
-            one_hot[0, target_class] = 1.0
-            outputs.backward(gradient=one_hot)
+            if face_bbox is not None:
+                _, _, H, W = image_tensor.shape
+                fx1, fy1, fx2, fy2 = face_bbox
+                fx1 = max(0, min(W, int(fx1)))
+                fy1 = max(0, min(H, int(fy1)))
+                fx2 = max(0, min(W, int(fx2)))
+                fy2 = max(0, min(H, int(fy2)))
+                mask = np.zeros_like(cam)
+                mask[fy1:fy2, fx1:fx2] = 1.0
+                cam = cam * mask
+                if cam.max() > 0:
+                    cam = cam / cam.max()
 
-            assert self._activations is not None, "Forward hook did not fire"
-            assert self._gradients is not None, "Backward hook did not fire"
-
-            activations = self._activations[0]  # (C, h, w)
-            gradients = self._gradients[0]  # (C, h, w)
-
-            weights = gradients.mean(dim=(1, 2))  # (C,)
-            cam = torch.einsum("c,chw->hw", weights, activations)  # (h, w)
-            cam = torch.clamp(cam, min=0)
-
-            cam_np = cam.cpu().numpy()
-            if cam_np.max() > 0:
-                cam_np = cam_np / cam_np.max()
-
-            _, _, H, W = image_tensor.shape
-            cam_resized = cv2.resize(cam_np, (W, H), interpolation=cv2.INTER_LINEAR)
-
-            return cam_resized.astype(np.float32)
+            return cam.astype(np.float32)
 
         finally:
-            self._remove_hooks()
-            self._activations = None
-            self._gradients = None
             if was_training:
                 self.model.train()
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-multipart>=0.0.6
 torch>=2.0.0
 torchvision>=0.15.0
 scikit-learn>=1.3.0
+grad-cam>=1.5.0
 
 # Data handling
 pillow>=10.0.0

--- a/backend/scripts/compare_cams.py
+++ b/backend/scripts/compare_cams.py
@@ -1,0 +1,169 @@
+"""
+Qualitative side-by-side comparison of Grad-CAM vs LayerCAM on XADE fakes.
+
+Runs both CAM methods through the existing GradCAMGenerator against the
+deepfake detector checkpoint used in production, and saves a single PNG per
+input showing: original | Grad-CAM overlay | LayerCAM overlay.
+
+Usage:
+    python -m backend.scripts.compare_cams
+    python -m backend.scripts.compare_cams --input desktop/public/quiz-images --output backend/tests/fixtures/cam_comparison
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from torchvision import transforms
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.api.detect import DeepfakeDetector  # noqa: E402
+from app.services.face_category_mapper import FaceCategoryMapper  # noqa: E402
+from app.services.gradcam_service import GradCAMGenerator  # noqa: E402
+from app.utils.model_loader import load_model_checkpoint  # noqa: E402
+
+DEFAULT_INPUT = REPO_ROOT / "desktop" / "public" / "quiz-images"
+DEFAULT_OUTPUT = BACKEND_ROOT / "tests" / "fixtures" / "cam_comparison"
+DEFAULT_IMAGES = ["Fake1.jpg", "Fake2.jpg", "Fake3.jpg", "Fake4.jpg", "Fake5.jpg"]
+
+_preprocess = transforms.Compose(
+    [
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+    ]
+)
+
+
+def _load_model(device: torch.device) -> torch.nn.Module:
+    checkpoint = load_model_checkpoint()
+    model = DeepfakeDetector().to(device)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+    return model
+
+
+def _scale_bbox_to_tensor(
+    bbox: tuple[int, int, int, int], orig_size: tuple[int, int]
+) -> tuple[int, int, int, int]:
+    orig_w, orig_h = orig_size
+    x1, y1, x2, y2 = bbox
+    return (
+        int(x1 * 224 / orig_w),
+        int(y1 * 224 / orig_h),
+        int(x2 * 224 / orig_w),
+        int(y2 * 224 / orig_h),
+    )
+
+
+def _compose_triptych(
+    original: Image.Image,
+    gradcam_overlay: Image.Image,
+    layercam_overlay: Image.Image,
+    title_height: int = 28,
+) -> Image.Image:
+    from PIL import ImageDraw, ImageFont
+
+    tile_w, tile_h = original.size
+    canvas = Image.new("RGB", (tile_w * 3, tile_h + title_height), "white")
+    canvas.paste(original, (0, title_height))
+    canvas.paste(gradcam_overlay, (tile_w, title_height))
+    canvas.paste(layercam_overlay, (tile_w * 2, title_height))
+
+    draw = ImageDraw.Draw(canvas)
+    try:
+        font = ImageFont.truetype("arial.ttf", 16)
+    except OSError:
+        font = ImageFont.load_default()
+
+    for idx, label in enumerate(["Original", "Grad-CAM (features[-1])", "LayerCAM (fused -2, -1)"]):
+        draw.text((tile_w * idx + 8, 4), label, fill="black", font=font)
+
+    return canvas
+
+
+def compare_image(
+    model: torch.nn.Module,
+    mapper: FaceCategoryMapper,
+    device: torch.device,
+    image_path: Path,
+    output_path: Path,
+) -> None:
+    image = Image.open(image_path).convert("RGB")
+    tensor = _preprocess(image).unsqueeze(0).to(device)
+
+    with torch.no_grad():
+        logits = model(tensor)
+        probs = torch.softmax(logits, dim=1)[0]
+        target_class = int(torch.argmax(probs).item())
+
+    face_bbox = mapper.detect_face_bbox(image)
+    tensor_bbox = _scale_bbox_to_tensor(face_bbox, image.size) if face_bbox else None
+
+    gen_gradcam = GradCAMGenerator(model, method="gradcam")
+    gen_layercam = GradCAMGenerator(model, method="layercam")
+
+    heatmap_gradcam = gen_gradcam.generate(tensor, target_class=target_class, face_bbox=tensor_bbox)
+    heatmap_layercam = gen_layercam.generate(
+        tensor, target_class=target_class, face_bbox=tensor_bbox
+    )
+
+    overlay_gradcam = gen_gradcam.create_overlay(image, heatmap_gradcam)
+    overlay_layercam = gen_layercam.create_overlay(image, heatmap_layercam)
+
+    triptych = _compose_triptych(image, overlay_gradcam, overlay_layercam)
+    triptych.save(output_path, format="PNG")
+
+    gradcam_peak_area = float(np.sum(heatmap_gradcam > 0.5)) / heatmap_gradcam.size
+    layercam_peak_area = float(np.sum(heatmap_layercam > 0.5)) / heatmap_layercam.size
+    print(
+        f"  {image_path.name}: "
+        f"pred={'fake' if target_class == 0 else 'real'} "
+        f"p={probs[target_class].item():.3f}  "
+        f"gradcam>0.5 area={gradcam_peak_area:.3f}  "
+        f"layercam>0.5 area={layercam_peak_area:.3f}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--images", nargs="*", default=DEFAULT_IMAGES)
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device(
+        "cuda"
+        if torch.cuda.is_available()
+        else ("mps" if torch.backends.mps.is_available() else "cpu")
+    )
+    print(f"Device: {device}")
+
+    model = _load_model(device)
+    mapper = FaceCategoryMapper()
+
+    print(f"Rendering {len(args.images)} comparison(s) into {args.output}")
+    for name in args.images:
+        image_path = args.input / name
+        if not image_path.exists():
+            print(f"  SKIP {name}: not found at {image_path}")
+            continue
+        output_path = args.output / f"{image_path.stem}_cam_comparison.png"
+        compare_image(model, mapper, device, image_path, output_path)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/fixtures/cam_comparison/README.md
+++ b/backend/tests/fixtures/cam_comparison/README.md
@@ -1,0 +1,43 @@
+# CAM method qualitative comparison
+
+Side-by-side renders of the XADE deepfake detector's attention under two CAM
+methods, both run through `backend/app/services/gradcam_service.py`:
+
+- **Grad-CAM** — Selvaraju et al. 2017, hooked on
+  `model.model.features[-1]` (the final conv block of EfficientNet-B4).
+- **LayerCAM** — Jiang et al. 2021, fused over `features[-2]` and
+  `features[-1]` via `pytorch_grad_cam.LayerCAM` with multi-layer targets.
+
+All five inputs are from `desktop/public/quiz-images/` (current study set,
+140k Real/Fake Faces, ~256²). The detector predicts `fake` with p=1.000 on
+every one, so CAM differences here are about **localization quality**, not
+about correctness. Face-bbox masking (applied before renormalization) is on
+for both methods to keep the comparison fair.
+
+Regenerate with:
+
+```bash
+python -m backend.scripts.compare_cams
+```
+
+## Per-image notes
+
+| Image       | Grad-CAM peak area (>0.5) | LayerCAM peak area (>0.5) | Which looks sharper |
+|-------------|---------------------------|---------------------------|---------------------|
+| Fake1.jpg   | 0.233                     | 0.152                     | **LayerCAM** — noticeably tighter; Grad-CAM bleeds onto the sky and shoulder. |
+| Fake2.jpg   | 0.078                     | 0.074                     | Roughly tied — both focus cleanly on the mouth/chin. |
+| Fake3.jpg   | 0.094                     | 0.077                     | **LayerCAM** — shifts peak off the beard onto the cheek, a more forensic-relevant region. |
+| Fake4.jpg   | 0.079                     | 0.071                     | Roughly tied — both center on the mouth. |
+| Fake5.jpg   | 0.104                     | 0.096                     | **LayerCAM** — marginally tighter around the mouth and nose. |
+
+## Caveats
+
+Both target layers used by LayerCAM (`features[-2]` and `features[-1]`) are
+already at the final 7×7 spatial resolution on EfficientNet-B4 with a 224²
+input, so multi-layer fusion here combines different channel perspectives
+rather than multiple resolutions. Expect modest gains on the existing
+256×256 Kaggle images; the improvement should be larger once study images
+are upgraded to 1024² FFHQ/StyleGAN3 (Issue 9).
+
+The old Grad-CAM path stays available via `CAM_METHOD=gradcam` for
+reproducibility of the thesis baseline.


### PR DESCRIPTION
Replaces the hand-rolled Grad-CAM hooks in gradcam_service.py with pytorch_grad_cam.LayerCAM, fused over features[-2] and features[-1]. Adds a CAM_METHOD env var (layercam default, gradcam fallback) so the baseline stays reproducible.

generate() now accepts a face_bbox and applies it before renormalization so background activations can't dominate the scale. _run_gradcam in analyses.py scales the PIL-space bbox into tensor coordinates before passing it through.

Adds backend/scripts/compare_cams.py plus a README at backend/tests/fixtures/cam_comparison/ documenting the 5-image side-by-side comparison. The rendered PNGs are gitignored and regenerated on demand. Closes #<79>.