### PR TITLE
feat: BiSeNet face parsing for pixel-accurate region-to-category mapping

### DIFF
--- a/backend/app/api/detect.py
+++ b/backend/app/api/detect.py
@@ -32,6 +32,7 @@ class_names = ["fake", "real"]
 # Set by main.py on startup — shared with routers that need category mapping.
 vlm_factory = None
 face_category_mapper = None
+face_parser = None
 
 
 class DeepfakeDetector(nn.Module):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,16 @@ async def lifespan(app: FastAPI):
         print(f"✗ Face category mapper failed to initialise: {e}")
         print("  (Region-to-category mapping will use label fallback)")
 
+    # Initialize BiSeNet face parser (pixel-accurate masks for 19 face classes)
+    try:
+        from app.services.face_parser import FaceParser
+
+        detect.face_parser = FaceParser()
+        print("✓ Face parser initialised (BiSeNet, weights lazy-loaded)")
+    except Exception as e:
+        print(f"✗ Face parser failed to initialise: {e}")
+        print("  (Region-to-category mapping will fall back to landmarks)")
+
     # Initialize VLM provider factory
     try:
         vlm_config = get_vlm_config()

--- a/backend/app/routers/analyses.py
+++ b/backend/app/routers/analyses.py
@@ -254,6 +254,7 @@ async def create_analysis(request: AnalysisRequest):
         class_names,
         device,
         face_category_mapper,
+        face_parser,
         model,
         transform,
         vlm_factory,
@@ -368,13 +369,25 @@ async def create_analysis(request: AnalysisRequest):
             # Extract region labels to pass to VLM for per-region comments
             region_labels = [r["label"] for r in evidence_regions] if evidence_regions else []
 
-            # Map evidence regions to face categories via MediaPipe landmarks.
+            # Run BiSeNet face parsing once per image — shared by region mapping.
+            # Falls back gracefully; the mapper uses landmarks when parsing is None.
+            parsing_result = None
+            if face_parser is not None:
+                try:
+                    parsing_result = face_parser.parse(image)
+                except Exception as e:
+                    logger.warning("Face parsing failed: %s", e)
+
+            # Map evidence regions to face categories. Priority:
+            # BiSeNet pixel overlap > MediaPipe landmark count > label fallback.
             # Uses raw crops (which retain bbox) rather than saved evidence_regions.
             # Merges category data into evidence_regions for storage and API response.
             region_categories = []
             if face_category_mapper is not None and crops:
                 try:
-                    categorized = face_category_mapper.map_regions(image, crops)
+                    categorized = face_category_mapper.map_regions(
+                        image, crops, parsing_result=parsing_result
+                    )
                     region_categories = [r.to_region_with_category() for r in categorized]
                     for ev_region, cat in zip(evidence_regions, categorized, strict=True):
                         ev_region["category_id"] = cat.category_id

--- a/backend/app/services/face_category_mapper.py
+++ b/backend/app/services/face_category_mapper.py
@@ -29,6 +29,7 @@ from mediapipe.tasks.python import vision as mp_vision
 from PIL import Image
 
 from app.services.categories import FACE_CATEGORIES, get_category_for_label
+from app.services.face_parser import FaceParsingResult
 from app.services.vlm.base import RegionWithCategory
 
 # Resolve model path relative to this file so it works both locally
@@ -175,6 +176,7 @@ class FaceCategoryMapper:
         self,
         image: Image.Image,
         evidence_regions: list[dict],
+        parsing_result: FaceParsingResult | None = None,
     ) -> list[CategorizedRegion]:
         """Map each GradCAM evidence region to its dominant face category.
 
@@ -182,6 +184,11 @@ class FaceCategoryMapper:
             image: The original PIL image used for landmark detection.
             evidence_regions: Output of GradCAMGenerator.extract_evidence_regions(),
                 a list of dicts with keys: image, label, activation_score, bbox.
+            parsing_result: Optional BiSeNet face-parsing masks.  When provided,
+                assignment uses pixel-area overlap between each bbox and each
+                UI category mask — more accurate than landmark counting near
+                boundaries.  Falls back to landmarks when no category has
+                overlapping pixels.
 
         Returns:
             List of CategorizedRegion in the same order as evidence_regions.
@@ -195,7 +202,10 @@ class FaceCategoryMapper:
         if landmarks_px is None:
             logger.debug("MediaPipe found no face — using label fallback for all regions")
 
-        return [self._categorize_region(region, landmarks_px) for region in evidence_regions]
+        return [
+            self._categorize_region(region, landmarks_px, parsing_result)
+            for region in evidence_regions
+        ]
 
     def _detect_landmarks(
         self,
@@ -225,19 +235,71 @@ class FaceCategoryMapper:
         self,
         region: dict,
         landmarks_px: list[tuple[int, int]] | None,
+        parsing_result: FaceParsingResult | None = None,
     ) -> CategorizedRegion:
         """Assign a face category to one evidence region.
 
-        Tries landmark-based spatial assignment first; falls back to
-        get_category_for_label() when landmarks are unavailable or when
-        no categorised landmarks fall inside the bounding box.
+        Priority order:
+        1. Pixel-area overlap with BiSeNet parsing masks (when provided).
+        2. MediaPipe landmark counting inside the bbox.
+        3. get_category_for_label() string lookup on the GradCAM label.
         """
+        if parsing_result is not None:
+            result = self._assign_by_parsing(region, parsing_result)
+            if result is not None:
+                return result
+
         if landmarks_px is not None:
             result = self._assign_by_landmarks(region, landmarks_px)
             if result is not None:
                 return result
 
         return self._fallback_region(region)
+
+    @staticmethod
+    def _assign_by_parsing(
+        region: dict,
+        parsing_result: FaceParsingResult,
+    ) -> CategorizedRegion | None:
+        """Spatial assignment: pick the UI category with the most pixels in the bbox.
+
+        Confidence is the winning category's pixel count divided by the total
+        number of categorised pixels inside the bbox (excluding background and
+        classes not in the UI merge, so fully-background bboxes return None).
+        """
+        x1, y1, x2, y2 = region["bbox"]
+        width, height = parsing_result.image_size
+        x1 = max(0, min(x1, width))
+        x2 = max(0, min(x2, width))
+        y1 = max(0, min(y1, height))
+        y2 = max(0, min(y2, height))
+        if x2 <= x1 or y2 <= y1:
+            return None
+
+        area_per_category: dict[str, int] = {}
+        total = 0
+        for cat_id, mask in parsing_result.masks_ui.items():
+            count = int(mask[y1:y2, x1:x2].sum())
+            if count > 0:
+                area_per_category[cat_id] = count
+                total += count
+
+        if not area_per_category:
+            return None
+
+        winning_id = max(area_per_category, key=lambda k: area_per_category[k])
+        confidence = area_per_category[winning_id] / total if total > 0 else 0.0
+        winning_category = FACE_CATEGORIES[winning_id]
+
+        return CategorizedRegion(
+            image=region["image"],
+            label=region["label"],
+            activation_score=region["activation_score"],
+            bbox=region["bbox"],
+            category_id=winning_id,
+            category_label=winning_category.label,
+            overlap_confidence=round(confidence, 4),
+        )
 
     def _assign_by_landmarks(
         self,

--- a/backend/app/services/face_parser.py
+++ b/backend/app/services/face_parser.py
@@ -1,0 +1,194 @@
+"""
+Pixel-accurate face parsing using BiSeNet trained on CelebAMask-HQ.
+
+Produces per-pixel semantic masks for 19 face classes (plus background) at the
+resolution of the input image.  Used by the face_category_mapper as a more
+accurate alternative to MediaPipe-landmark–based region assignment: instead of
+counting landmarks that fall inside a GradCAM bbox, the mapper can measure
+pixel-area overlap between the bbox and each UI category mask.
+
+The underlying model is the BiSeNet from zllrunning/face-parsing.PyTorch,
+ported and distributed by xinntao/facexlib.  Weights auto-download on first
+use into ``.venv/Lib/site-packages/facexlib/weights/parsing_bisenet.pth``
+(~50 MB).
+
+Output class ordering follows the CelebAMask-HQ convention:
+
+    0: background  1: skin      2: l_brow  3: r_brow   4: l_eye    5: r_eye
+    6: eye_g       7: l_ear     8: r_ear   9: ear_r   10: nose    11: mouth
+   12: u_lip      13: l_lip    14: neck   15: neck_l  16: cloth   17: hair
+   18: hat
+
+References:
+    Yu et al. (2018) "BiSeNet: Bilateral Segmentation Network for Real-time
+    Semantic Segmentation". Lee et al. (2020) "MaskGAN: Towards Diverse and
+    Interactive Facial Image Manipulation" (CelebAMask-HQ dataset).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from torchvision import transforms
+
+logger = logging.getLogger(__name__)
+
+
+# BiSeNet / CelebAMask-HQ 19-class label ordering.
+BISENET_CLASSES: tuple[str, ...] = (
+    "background",
+    "skin",
+    "l_brow",
+    "r_brow",
+    "l_eye",
+    "r_eye",
+    "eye_g",
+    "l_ear",
+    "r_ear",
+    "ear_r",
+    "nose",
+    "mouth",
+    "u_lip",
+    "l_lip",
+    "neck",
+    "neck_l",
+    "cloth",
+    "hair",
+    "hat",
+)
+
+
+# Merge rule: fine BiSeNet class name → UI category id (see FACE_CATEGORIES).
+# Classes not listed (background, hat, neck_l) are intentionally dropped.
+_FINE_TO_UI: dict[str, str] = {
+    "l_eye": "eyes_pupils",
+    "r_eye": "eyes_pupils",
+    "eye_g": "eyes_pupils",
+    "l_brow": "eyebrows_eyelashes",
+    "r_brow": "eyebrows_eyelashes",
+    "u_lip": "mouth_teeth",
+    "l_lip": "mouth_teeth",
+    "mouth": "mouth_teeth",
+    "skin": "skin_texture",
+    "hair": "hairline_ears",
+    "l_ear": "hairline_ears",
+    "r_ear": "hairline_ears",
+    "ear_r": "hairline_ears",
+    "nose": "facial_boundaries",
+    "neck": "facial_boundaries",
+    "cloth": "facial_boundaries",
+}
+
+
+@dataclass
+class FaceParsingResult:
+    """Per-pixel face-parsing masks at the original image resolution.
+
+    Attributes:
+        masks_fine: Mapping from BiSeNet class name (e.g. ``"l_eye"``) to a
+            boolean ``np.ndarray`` of shape ``(H, W)`` in the original image's
+            pixel coordinates.  Exactly one mask per :data:`BISENET_CLASSES`
+            entry; masks that are entirely absent still appear as all-False.
+        masks_ui: Mapping from UI category id (``"eyes_pupils"``, etc.) to the
+            union of the corresponding fine masks, same shape and dtype.
+        image_size: ``(width, height)`` of the original image in pixels.
+    """
+
+    masks_fine: dict[str, np.ndarray]
+    masks_ui: dict[str, np.ndarray]
+    image_size: tuple[int, int]
+
+
+class FaceParser:
+    """Lazy-initialised wrapper around facexlib's BiSeNet face parser.
+
+    The model is downloaded and loaded on the first call to :meth:`parse`,
+    then cached for subsequent calls.  Inference runs on CPU by default; set
+    ``FACE_PARSER_DEVICE=cuda`` to use GPU when available.
+
+    Inference is performed at :data:`inference_size` × :data:`inference_size`
+    (default 512) and the argmax mask is upsampled with nearest-neighbour to
+    the original image resolution.  Lowering the inference size to 256 via
+    ``FACE_PARSER_INFERENCE_SIZE`` roughly quarters runtime at the cost of
+    mask sharpness near boundaries.
+    """
+
+    _IMAGENET_MEAN = (0.485, 0.456, 0.406)
+    _IMAGENET_STD = (0.229, 0.224, 0.225)
+
+    def __init__(
+        self,
+        inference_size: int | None = None,
+        device: str | None = None,
+    ) -> None:
+        self.inference_size = inference_size or int(os.getenv("FACE_PARSER_INFERENCE_SIZE", "512"))
+        self.device = torch.device(device or os.getenv("FACE_PARSER_DEVICE", "cpu"))
+        self._model: torch.nn.Module | None = None
+        self._transform = transforms.Compose(
+            [
+                transforms.Resize(
+                    (self.inference_size, self.inference_size),
+                    interpolation=transforms.InterpolationMode.BILINEAR,
+                ),
+                transforms.ToTensor(),
+                transforms.Normalize(self._IMAGENET_MEAN, self._IMAGENET_STD),
+            ]
+        )
+
+    def _ensure_model(self) -> torch.nn.Module:
+        if self._model is None:
+            from facexlib.parsing import init_parsing_model
+
+            logger.info(
+                "Loading BiSeNet face parser (device=%s, inference_size=%d)",
+                self.device,
+                self.inference_size,
+            )
+            self._model = init_parsing_model(model_name="bisenet", device=str(self.device))
+            self._model.eval()
+        return self._model
+
+    def parse(self, image: Image.Image) -> FaceParsingResult:
+        """Run face parsing on a PIL image.
+
+        Args:
+            image: Any PIL image mode; converted to RGB internally.
+
+        Returns:
+            A :class:`FaceParsingResult` whose masks are in the original
+            image's pixel coordinates.
+        """
+        model = self._ensure_model()
+        rgb = image.convert("RGB")
+        orig_w, orig_h = rgb.size
+
+        input_tensor = self._transform(rgb).unsqueeze(0).to(self.device)
+
+        with torch.no_grad():
+            out = model(input_tensor)[0]  # (1, 19, H, W) at inference_size
+            out = F.interpolate(out, size=(orig_h, orig_w), mode="bilinear", align_corners=True)
+            class_map = out.argmax(dim=1).squeeze(0).cpu().numpy().astype(np.int64)
+
+        masks_fine: dict[str, np.ndarray] = {
+            name: (class_map == idx) for idx, name in enumerate(BISENET_CLASSES)
+        }
+
+        masks_ui: dict[str, np.ndarray] = {}
+        for fine_name, ui_id in _FINE_TO_UI.items():
+            mask = masks_fine[fine_name]
+            if ui_id in masks_ui:
+                masks_ui[ui_id] = masks_ui[ui_id] | mask
+            else:
+                masks_ui[ui_id] = mask.copy()
+
+        return FaceParsingResult(
+            masks_fine=masks_fine,
+            masks_ui=masks_ui,
+            image_size=(orig_w, orig_h),
+        )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,5 +39,8 @@ huggingface-hub>=0.14.0
 # MediaPipe (face landmark detection for region-to-category mapping)
 mediapipe>=0.10.0
 
+# BiSeNet face parsing (pixel-accurate masks for 19 face classes, CelebAMask-HQ)
+facexlib>=0.3.0
+
 # Testing
 pytest>=7.0.0

--- a/backend/tests/test_face_parser.py
+++ b/backend/tests/test_face_parser.py
@@ -1,0 +1,89 @@
+"""
+Smoke tests for :mod:`app.services.face_parser`.
+
+Downloads the BiSeNet weights on first run (~50 MB) and runs CPU inference on
+one quiz-set real face.  Skipped automatically when facexlib is not installed
+or when the test image is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+pytest.importorskip("facexlib", reason="facexlib required for face_parser tests")
+
+from app.services.face_parser import (  # noqa: E402
+    BISENET_CLASSES,
+    FaceParser,
+    FaceParsingResult,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_IMAGE = REPO_ROOT / "desktop" / "public" / "quiz-images" / "Real1.jpg"
+
+
+@pytest.fixture(scope="module")
+def parsing_result() -> FaceParsingResult:
+    if not TEST_IMAGE.exists():
+        pytest.skip(f"Test image not found at {TEST_IMAGE}")
+    image = Image.open(TEST_IMAGE).convert("RGB")
+    parser = FaceParser()
+    return parser.parse(image)
+
+
+class TestFaceParserStructure:
+    """Shape and dtype invariants of FaceParsingResult."""
+
+    def test_image_size_matches_input(self, parsing_result: FaceParsingResult) -> None:
+        assert parsing_result.image_size == Image.open(TEST_IMAGE).size
+
+    def test_fine_masks_have_all_19_classes(self, parsing_result: FaceParsingResult) -> None:
+        assert set(parsing_result.masks_fine) == set(BISENET_CLASSES)
+
+    def test_fine_masks_have_image_shape(self, parsing_result: FaceParsingResult) -> None:
+        width, height = parsing_result.image_size
+        for name, mask in parsing_result.masks_fine.items():
+            assert mask.shape == (height, width), f"{name} has wrong shape {mask.shape}"
+            assert mask.dtype == bool, f"{name} is not boolean (got {mask.dtype})"
+
+    def test_ui_masks_cover_expected_categories(self, parsing_result: FaceParsingResult) -> None:
+        expected = {
+            "eyes_pupils",
+            "eyebrows_eyelashes",
+            "mouth_teeth",
+            "skin_texture",
+            "hairline_ears",
+            "facial_boundaries",
+        }
+        assert set(parsing_result.masks_ui) == expected
+
+
+class TestFaceParserContent:
+    """Masks should be non-trivial for a clear real-face photo."""
+
+    @pytest.mark.parametrize("class_name", ["skin", "l_eye", "r_eye", "nose", "hair"])
+    def test_fine_mask_non_empty(self, parsing_result: FaceParsingResult, class_name: str) -> None:
+        mask = parsing_result.masks_fine[class_name]
+        assert mask.sum() > 0, f"BiSeNet produced empty mask for {class_name} on Real1.jpg"
+
+    def test_mouth_region_non_empty_via_ui_merge(self, parsing_result: FaceParsingResult) -> None:
+        """`mouth` fine class can be 0 on closed-mouth photos; the mouth_teeth
+        UI merge (mouth ∪ u_lip ∪ l_lip) is the contract downstream consumers
+        depend on, so assert that instead."""
+        assert parsing_result.masks_ui["mouth_teeth"].sum() > 0
+
+    @pytest.mark.parametrize(
+        "ui_id",
+        [
+            "eyes_pupils",
+            "eyebrows_eyelashes",
+            "mouth_teeth",
+            "skin_texture",
+            "hairline_ears",
+        ],
+    )
+    def test_ui_mask_non_empty(self, parsing_result: FaceParsingResult, ui_id: str) -> None:
+        assert parsing_result.masks_ui[ui_id].sum() > 0


### PR DESCRIPTION
Adds facexlib BiSeNet parser producing 19-class CelebAMask-HQ masks plus a 6-category UI merge (eyes_pupils, eyebrows_eyelashes, mouth_teeth, skin_texture, hairline_ears, facial_boundaries). The face category mapper now prefers pixel-area overlap between each GradCAM bbox and the UI masks, falling back to MediaPipe landmark counting when parsing is unavailable or produces no categorised pixels in the bbox.

Weights (~50 MB) auto-download on first use. CPU inference ~120 ms at 512x512 on the quiz images; FACE_PARSER_INFERENCE_SIZE and FACE_PARSER_DEVICE env vars override defaults.