### PR TITLE
feat: FFHQ+SG3 data pipeline and fine-tune harness for user study cur……ation

### DIFF
--- a/backend/scripts/download_ffhq.py
+++ b/backend/scripts/download_ffhq.py
@@ -1,0 +1,109 @@
+"""
+Download a subset of the FFHQ-1024 dataset from HuggingFace.
+
+Pulls N shards (1000 images each at 1024x1024, WebP) from
+`gaunernst/ffhq-1024-wds` and extracts the individual images into
+``backend/data/ffhq_sg3/raw/real/``.
+
+Each shard is downloaded once into the HuggingFace cache and can be
+re-extracted without re-downloading.  Images already present in the output
+directory are skipped, so the script is safe to re-run.
+
+Usage:
+    python -m backend.scripts.download_ffhq --shards 4
+    python -m backend.scripts.download_ffhq --shards 5 --output backend/data/ffhq_sg3/raw/real
+"""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download
+from tqdm import tqdm
+
+REPO_ID = "gaunernst/ffhq-1024-wds"
+REPO_TYPE = "dataset"
+SHARD_STEP = 1000  # shards are named 00000.tar, 01000.tar, 02000.tar, ...
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = REPO_ROOT / "backend" / "data" / "ffhq_sg3" / "raw" / "real"
+
+
+def shard_name(index: int) -> str:
+    """Return the tar filename for the Nth shard (0-indexed)."""
+    return f"{index * SHARD_STEP:05d}.tar"
+
+
+def extract_shard(tar_path: Path, output_dir: Path) -> int:
+    """Extract all .webp members from a shard into output_dir.
+
+    Returns the number of images newly written (existing files are skipped).
+    """
+    new_count = 0
+    with tarfile.open(tar_path, "r") as tar:
+        members = [m for m in tar.getmembers() if m.isfile() and m.name.endswith(".webp")]
+        for member in tqdm(members, desc=f"  extract {tar_path.name}", leave=False):
+            dest = output_dir / Path(member.name).name
+            if dest.exists():
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            dest.write_bytes(extracted.read())
+            new_count += 1
+    return new_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shards",
+        type=int,
+        default=4,
+        help="Number of 1000-image shards to download (default 4 = ~4000 images)",
+    )
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="Index of the first shard to download (default 0)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output directory (default {DEFAULT_OUTPUT})",
+    )
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    print(f"Output: {args.output}")
+    print(f"Pulling {args.shards} shard(s) starting at index {args.start}")
+
+    total_new = 0
+    for i in range(args.start, args.start + args.shards):
+        filename = shard_name(i)
+        print(f"\n[{i - args.start + 1}/{args.shards}] {filename}")
+        try:
+            tar_path = Path(
+                hf_hub_download(
+                    repo_id=REPO_ID,
+                    repo_type=REPO_TYPE,
+                    filename=filename,
+                )
+            )
+        except Exception as exc:
+            print(f"  skip {filename}: {exc}")
+            continue
+        new = extract_shard(tar_path, args.output)
+        total_new += new
+        print(f"  +{new} new images")
+
+    existing = len(list(args.output.glob("*.webp")))
+    print(f"\nDone. {total_new} new image(s) written, {existing} total in {args.output}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/fine_tune_ffhq_sg3.py
+++ b/backend/scripts/fine_tune_ffhq_sg3.py
@@ -1,0 +1,251 @@
+"""
+Fine-tune the deepfake detector on the FFHQ+SG3 dataset.
+
+Loads ``best_model_140k_ciplab_ffpp.pt`` (the latest checkpoint from the
+progressive cross-dataset runs) and continues training at a low learning
+rate on the FFHQ+SG3 train/val split produced by ``prepare_ffhq_sg3.py``.
+
+The goal is to bring detector accuracy on the FFHQ+SG3 held-out test set up
+to a level where the 12 user-study images can be selected as all-correctly
+classified — so the user study evaluates VLM explanation quality rather
+than detector failures.
+
+The fine-tune uses separate learning rates for the backbone (very low, so
+we don't destroy the existing feature representations) and the classifier
+head (slightly higher, so it can adapt to the new distribution).
+
+Usage:
+    python -m backend.scripts.fine_tune_ffhq_sg3
+    python -m backend.scripts.fine_tune_ffhq_sg3 --epochs 5 --lr-classifier 2e-5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+from torchvision import transforms
+from tqdm import tqdm
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend" / "models"))
+from train_detector import DeepfakeDetector, SafeImageFolder  # noqa: E402
+
+DEFAULT_RESUME = REPO_ROOT / "backend" / "checkpoints" / "best_model_140k_ciplab_ffpp.pt"
+DEFAULT_DATA = REPO_ROOT / "backend" / "data" / "ffhq_sg3"
+DEFAULT_OUTPUT = REPO_ROOT / "backend" / "checkpoints" / "best_model_140k_ciplab_ffpp_ffhq_sg3.pt"
+DEFAULT_HISTORY = REPO_ROOT / "backend" / "results" / "ffhq_sg3_finetune_history.json"
+
+IMAGENET_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STD = [0.229, 0.224, 0.225]
+
+
+def build_transforms() -> tuple[transforms.Compose, transforms.Compose]:
+    """Training transforms use mild augmentation; val uses deterministic resize."""
+    train_t = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.ColorJitter(brightness=0.15, contrast=0.15),
+            transforms.ToTensor(),
+            transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD),
+        ]
+    )
+    val_t = transforms.Compose(
+        [
+            transforms.Resize((224, 224)),
+            transforms.ToTensor(),
+            transforms.Normalize(IMAGENET_MEAN, IMAGENET_STD),
+        ]
+    )
+    return train_t, val_t
+
+
+def load_resume_checkpoint(model: nn.Module, resume_path: Path) -> int:
+    """Load weights from ``resume_path`` into ``model``.
+
+    Returns the epoch index stored in the checkpoint, for logging only.
+    """
+    checkpoint = torch.load(resume_path, map_location="cpu", weights_only=False)
+    model.load_state_dict(checkpoint["model_state_dict"])
+    prior_epochs = int(checkpoint.get("epoch", -1)) + 1
+    classes = checkpoint.get("class_names", ["?", "?"])
+    print(f"Loaded {resume_path.name} (trained {prior_epochs} epochs, classes={classes})")
+    return prior_epochs
+
+
+def run_epoch(
+    model: nn.Module,
+    loader: DataLoader,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer | None,
+    device: torch.device,
+    desc: str,
+) -> tuple[float, float]:
+    """One pass over ``loader``. Pass ``optimizer=None`` for eval."""
+    is_train = optimizer is not None
+    model.train(is_train)
+    total_loss = 0.0
+    correct = 0
+    total = 0
+
+    context = torch.enable_grad() if is_train else torch.no_grad()
+    with context:
+        for images, labels in tqdm(loader, desc=desc, leave=False):
+            images = images.to(device, non_blocking=True)
+            labels = labels.to(device, non_blocking=True)
+
+            if is_train:
+                optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            if is_train:
+                loss.backward()
+                optimizer.step()
+
+            total_loss += loss.item() * images.size(0)
+            correct += outputs.argmax(dim=1).eq(labels).sum().item()
+            total += images.size(0)
+
+    return total_loss / total, 100.0 * correct / total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--resume", type=Path, default=DEFAULT_RESUME)
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA)
+    parser.add_argument("--train-subdir", default="train")
+    parser.add_argument("--val-subdir", default="val")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--history", type=Path, default=DEFAULT_HISTORY)
+    parser.add_argument("--epochs", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr-classifier", type=float, default=1e-5)
+    parser.add_argument("--lr-backbone", type=float, default=1e-6)
+    parser.add_argument("--weight-decay", type=float, default=0.01)
+    parser.add_argument("--patience", type=int, default=3)
+    parser.add_argument("--num-workers", type=int, default=0)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+    if device.type == "cpu":
+        print("WARNING: running on CPU — fine-tune will be very slow.")
+
+    train_t, val_t = build_transforms()
+    train_dir = args.data / args.train_subdir
+    val_dir = args.data / args.val_subdir
+    train_ds = SafeImageFolder(root=str(train_dir), transform=train_t)
+    val_ds = SafeImageFolder(root=str(val_dir), transform=val_t)
+    print(f"Train: {len(train_ds)} images from {train_dir} (classes={train_ds.classes})")
+    print(f"Val:   {len(val_ds)} images from {val_dir}")
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+
+    model = DeepfakeDetector().to(device)
+    prior_epochs = load_resume_checkpoint(model, args.resume)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": model.model.features.parameters(), "lr": args.lr_backbone},
+            {"params": model.model.classifier.parameters(), "lr": args.lr_classifier},
+        ],
+        weight_decay=args.weight_decay,
+    )
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", patience=2, factor=0.5
+    )
+    print(
+        f"Fine-tune: {args.epochs} epochs, batch={args.batch_size}, "
+        f"lr_classifier={args.lr_classifier:.0e}, lr_backbone={args.lr_backbone:.0e}"
+    )
+
+    best_val_acc = 0.0
+    patience_counter = 0
+    history: dict = {
+        "resumed_from": str(args.resume),
+        "prior_epochs": prior_epochs,
+        "config": {
+            "epochs": args.epochs,
+            "batch_size": args.batch_size,
+            "lr_classifier": args.lr_classifier,
+            "lr_backbone": args.lr_backbone,
+            "weight_decay": args.weight_decay,
+        },
+        "epochs": [],
+        "started_at": datetime.now().isoformat(),
+    }
+
+    for epoch in range(args.epochs):
+        print(f"\n=== Epoch {epoch + 1}/{args.epochs} ===")
+        train_loss, train_acc = run_epoch(
+            model, train_loader, criterion, optimizer, device, desc="train"
+        )
+        val_loss, val_acc = run_epoch(model, val_loader, criterion, None, device, desc="val")
+        scheduler.step(val_loss)
+        print(
+            f"  train: loss={train_loss:.4f} acc={train_acc:.2f}%  |  "
+            f"val: loss={val_loss:.4f} acc={val_acc:.2f}%"
+        )
+
+        history["epochs"].append(
+            {
+                "epoch": epoch + 1,
+                "train_loss": round(train_loss, 4),
+                "train_acc": round(train_acc, 2),
+                "val_loss": round(val_loss, 4),
+                "val_acc": round(val_acc, 2),
+            }
+        )
+
+        if val_acc > best_val_acc:
+            best_val_acc = val_acc
+            patience_counter = 0
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            torch.save(
+                {
+                    "epoch": prior_epochs + epoch,
+                    "model_state_dict": model.state_dict(),
+                    "val_acc": val_acc,
+                    "class_names": train_ds.classes,
+                    "resumed_from": args.resume.name,
+                },
+                args.output,
+            )
+            print(f"  saved (val_acc={val_acc:.2f}%) -> {args.output.name}")
+        else:
+            patience_counter += 1
+            print(f"  no improvement ({patience_counter}/{args.patience})")
+            if patience_counter >= args.patience:
+                print(f"  early stopping after epoch {epoch + 1}")
+                break
+
+    history["best_val_acc"] = round(best_val_acc, 2)
+    history["finished_at"] = datetime.now().isoformat()
+    args.history.parent.mkdir(parents=True, exist_ok=True)
+    args.history.write_text(json.dumps(history, indent=2))
+    print(f"\nDone. best_val_acc={best_val_acc:.2f}% -> {args.output}\nhistory -> {args.history}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/generate_sg3.py
+++ b/backend/scripts/generate_sg3.py
@@ -161,10 +161,7 @@ def main() -> None:
         print("WARNING: running on CPU — generation will be extremely slow.")
 
     generator = load_generator(device)
-    print(
-        f"Generator loaded: z_dim={generator.z_dim}, "
-        f"img_resolution={generator.img_resolution}"
-    )
+    print(f"Generator loaded: z_dim={generator.z_dim}, img_resolution={generator.img_resolution}")
 
     args.output.mkdir(parents=True, exist_ok=True)
     print(f"Output: {args.output}")

--- a/backend/scripts/generate_sg3.py
+++ b/backend/scripts/generate_sg3.py
@@ -1,0 +1,199 @@
+"""
+Generate synthetic faces with StyleGAN3-T (FFHQ-U, 1024x1024).
+
+Clones the NVlabs/stylegan3 repository and downloads the official pretrained
+``stylegan3-t-ffhqu-1024x1024.pkl`` checkpoint on first run, then generates
+N images at the requested truncation psi and saves them as WebP into
+``backend/data/ffhq_sg3/raw/fake/``.
+
+The NVlabs custom CUDA ops (bias_act, upfirdn2d, filtered_lrelu) need a C++
+compiler and CUDA toolkit to build; instead of requiring those we
+monkey-patch the `_init` function of each op to force the pure-PyTorch
+reference implementation.  The generator still runs fully on GPU through
+PyTorch's bundled CUDA runtime, just ~3-5x slower than the compiled path
+— which is fine for a one-time batch generation.
+
+Usage:
+    python -m backend.scripts.generate_sg3 --count 1000 --truncation 0.7
+    python -m backend.scripts.generate_sg3 --count 100 --truncation 1.0 --seed-offset 10000
+
+Generations are deterministic per ``seed``; re-running with the same
+``--seed-offset`` and ``--count`` will produce identical images (and skip
+ones already on disk).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import pickle
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from tqdm import tqdm
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SG3_ROOT = REPO_ROOT / "backend" / "data" / "stylegan3"
+SG3_REPO_URL = "https://github.com/NVlabs/stylegan3.git"
+SG3_CHECKPOINT_URL = (
+    "https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan3/"
+    "versions/1/files/stylegan3-t-ffhqu-1024x1024.pkl"
+)
+CHECKPOINT_PATH = SG3_ROOT / "stylegan3-t-ffhqu-1024x1024.pkl"
+
+DEFAULT_OUTPUT = REPO_ROOT / "backend" / "data" / "ffhq_sg3" / "raw" / "fake"
+
+
+def ensure_repo() -> None:
+    """Clone NVlabs/stylegan3 if it's not already on disk."""
+    if (SG3_ROOT / "torch_utils").exists():
+        return
+    SG3_ROOT.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Cloning {SG3_REPO_URL} -> {SG3_ROOT}")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", SG3_REPO_URL, str(SG3_ROOT)],
+        check=True,
+    )
+
+
+def ensure_checkpoint() -> Path:
+    """Download the pretrained StyleGAN3-T FFHQ checkpoint (~300 MB)."""
+    if CHECKPOINT_PATH.exists():
+        return CHECKPOINT_PATH
+    CHECKPOINT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading checkpoint -> {CHECKPOINT_PATH}")
+    with urllib.request.urlopen(SG3_CHECKPOINT_URL) as response:
+        total = int(response.headers.get("Content-Length", 0))
+        with (
+            open(CHECKPOINT_PATH, "wb") as f,
+            tqdm(total=total, unit="B", unit_scale=True, desc="  weights") as bar,
+        ):
+            while chunk := response.read(1024 * 1024):
+                f.write(chunk)
+                bar.update(len(chunk))
+    return CHECKPOINT_PATH
+
+
+def force_reference_ops() -> None:
+    """Make StyleGAN3's custom CUDA ops fall back to pure-PyTorch reference code.
+
+    Overriding each ``_init`` to return False skips plugin compilation (which
+    would need nvcc + MSVC on Windows) and routes every op through its
+    bundled ``*_ref`` implementation instead.
+    """
+    from torch_utils.ops import bias_act, filtered_lrelu, upfirdn2d
+
+    bias_act._init = lambda: False
+    upfirdn2d._init = lambda: False
+    filtered_lrelu._init = lambda: False
+
+
+def load_generator(device: torch.device) -> torch.nn.Module:
+    """Load the StyleGAN3 generator from the pretrained pickle."""
+    checkpoint = ensure_checkpoint()
+    with open(checkpoint, "rb") as f:
+        network = pickle.load(f)
+    generator = network["G_ema"].to(device)
+    generator.eval()
+    return generator
+
+
+def generate_image(
+    generator: torch.nn.Module,
+    seed: int,
+    truncation: float,
+    device: torch.device,
+) -> Image.Image:
+    """Generate one 1024x1024 RGB image from a fixed seed."""
+    z = torch.from_numpy(np.random.RandomState(seed).randn(1, generator.z_dim)).to(device)
+    with torch.no_grad():
+        img = generator(z, None, truncation_psi=truncation, noise_mode="const")
+    img = (img.clamp(-1, 1) + 1) * (255.0 / 2.0)
+    array = img[0].permute(1, 2, 0).to(torch.uint8).cpu().numpy()
+    return Image.fromarray(array, "RGB")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--count", type=int, default=100, help="Number of images to generate")
+    parser.add_argument(
+        "--truncation",
+        type=float,
+        default=0.7,
+        help="Truncation psi. 0.7 produces near-mean faces (sharp, few artifacts); "
+        "1.0 produces the raw distribution (more diverse, more artifacts).",
+    )
+    parser.add_argument(
+        "--seed-offset",
+        type=int,
+        default=0,
+        help="Starting seed. Use different offsets to generate disjoint sets.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output directory (default {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--quality",
+        type=int,
+        default=95,
+        help="WebP quality (default 95, near-lossless).",
+    )
+    args = parser.parse_args()
+
+    ensure_repo()
+    if str(SG3_ROOT) not in sys.path:
+        sys.path.insert(0, str(SG3_ROOT))
+
+    force_reference_ops()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+    if device.type == "cpu":
+        print("WARNING: running on CPU — generation will be extremely slow.")
+
+    generator = load_generator(device)
+    print(
+        f"Generator loaded: z_dim={generator.z_dim}, "
+        f"img_resolution={generator.img_resolution}"
+    )
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    print(f"Output: {args.output}")
+    print(
+        f"Generating {args.count} image(s) at psi={args.truncation}, "
+        f"seeds {args.seed_offset}..{args.seed_offset + args.count - 1}"
+    )
+
+    new_count = 0
+    skipped = 0
+    psi_tag = f"psi{int(round(args.truncation * 100)):03d}"
+    for i in tqdm(range(args.count), desc="generating"):
+        seed = args.seed_offset + i
+        dest = args.output / f"sg3_{psi_tag}_seed{seed:07d}.webp"
+        if dest.exists():
+            skipped += 1
+            continue
+        img = generate_image(generator, seed, args.truncation, device)
+        buf = io.BytesIO()
+        img.save(buf, format="WEBP", quality=args.quality, method=4)
+        dest.write_bytes(buf.getvalue())
+        new_count += 1
+
+    existing = len(list(args.output.glob("*.webp")))
+    print(
+        f"\nDone. {new_count} generated, {skipped} skipped (already present), "
+        f"{existing} total in {args.output}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/prepare_ffhq_sg3.py
+++ b/backend/scripts/prepare_ffhq_sg3.py
@@ -1,0 +1,145 @@
+"""
+Split the FFHQ+SG3 raw set into train/val/test folders.
+
+Reads from ``backend/data/ffhq_sg3/raw/{real,fake}/`` (populated by
+``download_ffhq.py`` and ``generate_sg3.py``) and produces an 80/10/10
+split into ``backend/data/ffhq_sg3/{train,val,test}/{real,fake}/``.
+
+The split is deterministic (``random_state=42`` on a sorted filename list),
+so re-running with the same raw contents always produces the same
+assignments.  This matters for Issue 9's methodology: the 12 study images
+are drawn from ``test/``, never from ``train/`` or ``val/``, so the
+fine-tune never sees them.
+
+By default, files are hardlinked rather than copied — saves ~8 GB on the
+full run.  Pass ``--copy`` to fall back to a real copy (required when
+destination is on a different volume than the source).
+
+Usage:
+    python -m backend.scripts.prepare_ffhq_sg3
+    python -m backend.scripts.prepare_ffhq_sg3 --copy
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+from sklearn.model_selection import train_test_split
+from tqdm import tqdm
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE = REPO_ROOT / "backend" / "data" / "ffhq_sg3" / "raw"
+DEFAULT_DEST = REPO_ROOT / "backend" / "data" / "ffhq_sg3"
+
+SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
+SPLITS = ("train", "val", "test")
+
+
+def collect_images(directory: Path) -> list[Path]:
+    """Return a sorted list of image paths under ``directory``."""
+    images: list[Path] = []
+    for path in directory.iterdir():
+        if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS:
+            images.append(path)
+    images.sort()
+    return images
+
+
+def place_file(src: Path, dest: Path, *, copy: bool) -> None:
+    """Hardlink (default) or copy ``src`` to ``dest``, skipping if present."""
+    if dest.exists():
+        return
+    if copy:
+        shutil.copy2(src, dest)
+        return
+    try:
+        os.link(src, dest)
+    except OSError:
+        # Different volume, or filesystem rejects hardlinks — fall back.
+        shutil.copy2(src, dest)
+
+
+def split_label(
+    images: list[Path],
+    label: str,
+    dest_root: Path,
+    *,
+    copy: bool,
+    seed: int,
+) -> dict[str, int]:
+    """Split one label's images into train/val/test under ``dest_root``.
+
+    Returns a ``{split_name: count}`` mapping.
+    """
+    train, temp = train_test_split(images, test_size=0.2, random_state=seed)
+    val, test = train_test_split(temp, test_size=0.5, random_state=seed)
+
+    counts: dict[str, int] = {}
+    for split_name, split_images in (("train", train), ("val", val), ("test", test)):
+        split_dir = dest_root / split_name / label
+        split_dir.mkdir(parents=True, exist_ok=True)
+        for img in tqdm(split_images, desc=f"  {split_name}/{label}", leave=False):
+            place_file(img, split_dir / img.name, copy=copy)
+        counts[split_name] = len(split_images)
+    return counts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_SOURCE,
+        help=f"Raw image root with real/ and fake/ subdirs (default {DEFAULT_SOURCE})",
+    )
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=DEFAULT_DEST,
+        help=f"Destination root for the split (default {DEFAULT_DEST})",
+    )
+    parser.add_argument(
+        "--copy",
+        action="store_true",
+        help="Copy files instead of hardlinking (required across volumes).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for the split (default 42).",
+    )
+    args = parser.parse_args()
+
+    real_src = args.source / "real"
+    fake_src = args.source / "fake"
+    if not real_src.exists() or not fake_src.exists():
+        raise FileNotFoundError(
+            f"Expected {real_src} and {fake_src} — run download_ffhq.py and generate_sg3.py first."
+        )
+
+    real_images = collect_images(real_src)
+    fake_images = collect_images(fake_src)
+    print(f"Found {len(real_images)} real and {len(fake_images)} fake images")
+    print(f"Source: {args.source}")
+    print(f"Dest:   {args.dest}")
+    print(f"Mode:   {'copy' if args.copy else 'hardlink'} (seed={args.seed})")
+
+    real_counts = split_label(real_images, "real", args.dest, copy=args.copy, seed=args.seed)
+    fake_counts = split_label(fake_images, "fake", args.dest, copy=args.copy, seed=args.seed)
+
+    print("\n=== Split Summary ===")
+    for split in SPLITS:
+        real_on_disk = len(list((args.dest / split / "real").glob("*.*")))
+        fake_on_disk = len(list((args.dest / split / "fake").glob("*.*")))
+        print(
+            f"{split:5s}: {real_counts[split]:>5d} real (on disk: {real_on_disk}), "
+            f"{fake_counts[split]:>5d} fake (on disk: {fake_on_disk})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/run_ciplab_eval.py
+++ b/backend/scripts/run_ciplab_eval.py
@@ -90,7 +90,7 @@ def compute_metrics(y_true, y_pred, y_probs, dataset_name: str) -> dict:
 
 def print_results(metrics: dict) -> None:
     print("\n" + "=" * 50)
-    print(f"CIPLAB EVALUATION — {metrics['dataset']}")
+    print(f"EVALUATION — {metrics['dataset']}")
     print("=" * 50)
     print(
         f"  Samples:   {metrics['n_samples']} ({metrics['n_real']} real, {metrics['n_fake']} fake)"
@@ -108,6 +108,7 @@ if __name__ == "__main__":
     parser.add_argument("--model", default="backend/checkpoints/best_model.pt")
     parser.add_argument("--data", default="backend/data/ciplab")
     parser.add_argument("--output", default="backend/results/ciplab_evaluation.json")
+    parser.add_argument("--name", default="CIPLAB", help="Dataset label to embed in the results JSON.")
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
 
@@ -116,7 +117,7 @@ if __name__ == "__main__":
 
     model = load_model(args.model, device)
     y_true, y_pred, y_probs, classes = run_inference(model, args.data, device)
-    metrics = compute_metrics(y_true, y_pred, y_probs, dataset_name="CIPLAB")
+    metrics = compute_metrics(y_true, y_pred, y_probs, dataset_name=args.name)
 
     print_results(metrics)
 

--- a/backend/scripts/run_ciplab_eval.py
+++ b/backend/scripts/run_ciplab_eval.py
@@ -108,7 +108,9 @@ if __name__ == "__main__":
     parser.add_argument("--model", default="backend/checkpoints/best_model.pt")
     parser.add_argument("--data", default="backend/data/ciplab")
     parser.add_argument("--output", default="backend/results/ciplab_evaluation.json")
-    parser.add_argument("--name", default="CIPLAB", help="Dataset label to embed in the results JSON.")
+    parser.add_argument(
+        "--name", default="CIPLAB", help="Dataset label to embed in the results JSON."
+    )
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
 


### PR DESCRIPTION


- download_ffhq.py: pull 1000-image shards from gaunernst/ffhq-1024-wds
- generate_sg3.py: StyleGAN3-T FFHQ-U synthesis via NVlabs pretrained, with pure-PyTorch fallback for the custom CUDA ops
- prepare_ffhq_sg3.py: deterministic 80/10/10 split (seed=42) via hardlinks
- fine_tune_ffhq_sg3.py: low-LR fine-tune from best_model_140k_ciplab_ffpp.pt
- run_ciplab_eval.py: parameterize dataset label via --name

Produces an 800-image held-out test pool (400 real FFHQ, 400 StyleGAN3 fake) from which the 12 user-study images will be drawn, plus a 6400-image train set the detector can be fine-tuned on without ever seeing the study images.