### PR TITLE
feat(vlm): enrich prompt with [FORENSIC EVIDENCE] block and ELA overlay (#84)

### DIFF
--- a/backend/app/routers/analyses.py
+++ b/backend/app/routers/analyses.py
@@ -230,11 +230,14 @@ def _build_ranked_evidence(
     heatmap: np.ndarray,
     parsing_result,
     face_bbox: tuple[int, int, int, int] | None = None,
-) -> tuple[list[dict], list[dict]] | None:
-    """Run forensics + region ranker, returning ``(evidence_regions, crops)``.
+):
+    """Run forensics + region ranker.
 
-    Returns ``None`` when forensics or ranking raises, so the caller can fall
-    back to the legacy CAM-only evidence extraction path.
+    Returns ``(evidence_regions, crops, forensics_report)`` on success, or
+    ``None`` when forensics or ranking raises so the caller can fall back to
+    the legacy CAM-only evidence extraction path. The forensics report is
+    surfaced so the VLM prompt can render the ``[FORENSIC EVIDENCE]`` block
+    even when no individual region clears the suspicion threshold.
     """
     try:
         from app.services.categories import FACE_CATEGORIES
@@ -284,7 +287,7 @@ def _build_ranked_evidence(
                 ev["category_label"] = face_cat.label
                 ev["common_artifacts"] = list(face_cat.common_artifacts[:3])
 
-        return evidence_regions, crops
+        return evidence_regions, crops, forensics_report
 
     except Exception as exc:
         logger.warning("Region ranker path failed, falling back: %s", exc)
@@ -506,10 +509,11 @@ async def create_analysis(request: AnalysisRequest):
 
             ranker_used = False
             region_categories: list[RegionWithCategory] = []
+            forensics_report = None
             if parsing_result is not None and heatmap is not None:
                 ranked = _build_ranked_evidence(image, heatmap, parsing_result, face_bbox=face_bbox)
                 if ranked is not None:
-                    evidence_regions, crops = ranked
+                    evidence_regions, crops, forensics_report = ranked
                     ranker_used = True
 
             # Fallback: run the legacy MediaPipe/label-based mapper over the
@@ -553,6 +557,26 @@ async def create_analysis(request: AnalysisRequest):
             vlm_explanation_text = None
             vlm_model_used = None
 
+            # Build the ELA overlay once per analysis. Mirrors the GradCAM
+            # overlay pattern so the VLM gets a visually consistent evidence
+            # image. Only sent when forensics ran successfully — otherwise
+            # the prompt builder skips the [FORENSIC EVIDENCE] block too.
+            ela_bytes = None
+            if forensics_report is not None:
+                try:
+                    from app.services.forensics.ela import (
+                        compute_ela,
+                        create_ela_overlay,
+                    )
+
+                    ela_map = compute_ela(image, quality=95, scale=10)
+                    ela_overlay = create_ela_overlay(image, ela_map)
+                    buf = io.BytesIO()
+                    ela_overlay.save(buf, format="PNG")
+                    ela_bytes = buf.getvalue()
+                except Exception as e:
+                    logger.warning("ELA overlay generation failed: %s", e)
+
             if vlm_factory is not None:
                 try:
                     detection_context = DetectionContext(
@@ -562,6 +586,7 @@ async def create_analysis(request: AnalysisRequest):
                         probabilities={"fake": fake_prob, "real": real_prob},
                         region_labels=region_labels,
                         region_categories=region_categories,
+                        forensics_report=forensics_report,
                     )
 
                     # Convert region crop PIL images to JPEG bytes for VLM
@@ -578,6 +603,7 @@ async def create_analysis(request: AnalysisRequest):
                         detection=detection_context,
                         gradcam_available=gradcam_available,
                         region_image_bytes=region_image_bytes if region_image_bytes else None,
+                        ela_bytes=ela_bytes,
                     )
 
                     print("VLM raw response:", vlm_explanation.raw_response)

--- a/backend/app/services/forensics/ela.py
+++ b/backend/app/services/forensics/ela.py
@@ -50,6 +50,46 @@ def compute_ela(image: Image.Image, quality: int = 95, scale: int = 10) -> Image
     return Image.fromarray(residual, mode="RGB")
 
 
+def create_ela_overlay(
+    original: Image.Image,
+    ela_map: Image.Image,
+    alpha: float = 0.55,
+) -> Image.Image:
+    """Blend an ELA residual map faintly over the original image.
+
+    Mirrors the GradCAM overlay pattern so the VLM receives a visually
+    consistent set of evidence images. The ELA map is converted to a single
+    luminance channel and recoloured with a hot colormap (dark = no residual,
+    bright yellow/white = strong residual) so anomalies pop visually.
+
+    Args:
+        original: Source PIL image (any mode; converted to RGB internally).
+        ela_map: ELA residual image from :func:`compute_ela`.
+        alpha: Overlay blend weight (0 = original only, 1 = ELA only).
+
+    Returns:
+        PIL RGB image of the same size as *original* with the ELA residual
+        rendered as a faint hot colormap on top.
+    """
+    rgb = original.convert("RGB")
+    orig_arr = np.array(rgb, dtype=np.float32)
+
+    # Use luminance of the residual as scalar intensity, then map to a
+    # red-yellow gradient so high-residual areas are visually obvious.
+    ela_resized = ela_map.convert("L").resize(rgb.size, Image.BILINEAR)
+    intensity = np.array(ela_resized, dtype=np.float32) / 255.0
+    intensity = np.clip(intensity, 0.0, 1.0)
+
+    coloured = np.zeros_like(orig_arr)
+    coloured[..., 0] = 255.0 * np.minimum(1.0, intensity * 2.0)  # R
+    coloured[..., 1] = 255.0 * np.clip(intensity * 2.0 - 0.5, 0.0, 1.0)  # G
+    coloured[..., 2] = 0.0  # B
+
+    overlay = (1.0 - alpha) * orig_arr + alpha * coloured
+    overlay = np.clip(overlay, 0, 255).astype(np.uint8)
+    return Image.fromarray(overlay, mode="RGB")
+
+
 def ela_intensity_per_region(
     ela_map: Image.Image,
     masks: dict[str, np.ndarray],

--- a/backend/app/services/vlm/base.py
+++ b/backend/app/services/vlm/base.py
@@ -7,7 +7,10 @@ Uses the strategy pattern so providers can be swapped without changing the rest 
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from app.services.forensics.report import ForensicsReport
 
 
 @dataclass
@@ -82,6 +85,10 @@ class DetectionContext:
     # categories.get_category_for_label() resolves a label successfully.
     # Providers and prompt_builder prefer this over plain region_labels.
     region_categories: list[RegionWithCategory] = field(default_factory=list)
+    # Per-region forensic metrics (sharpness, HF energy, ELA intensity).
+    # When present, prompt_builder emits a [FORENSIC EVIDENCE] block that the
+    # VLM can cite by name; absence falls back to today's CAM-only behavior.
+    forensics_report: Optional["ForensicsReport"] = None
 
 
 class BaseVLMProvider(ABC):
@@ -102,6 +109,7 @@ class BaseVLMProvider(ABC):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         """
         Generate a structured explanation from the VLM provider.
@@ -111,13 +119,19 @@ class BaseVLMProvider(ABC):
             heatmap_bytes: The GradCAM heatmap in bytes. Only sent to the
                            VLM when gradcam_available is True.
             detection: The detection results to ground the explanation.
-                       Includes region_labels from GradCAM evidence crops.
+                       Includes region_labels from GradCAM evidence crops and,
+                       when available, a forensics_report whose metrics the
+                       prompt builder turns into a [FORENSIC EVIDENCE] block.
             gradcam_available: Whether heatmap_bytes contains a real heatmap.
             region_image_bytes: Optional list of zoomed-in region crop images
                                 in the same order as detection.region_categories.
                                 When provided, each crop is sent to the VLM as
                                 a separate image so it can inspect the artifact
                                 up close rather than inferring from the full image.
+            ela_bytes: Optional ELA (Error Level Analysis) overlay image in PNG
+                       bytes. Sent to the VLM after the GradCAM heatmap and
+                       before the region crops so the model can ground claims
+                       in visible recompression residuals.
 
         Returns:
             VLMExplanation with summary, detailed analysis, technical notes,

--- a/backend/app/services/vlm/factory.py
+++ b/backend/app/services/vlm/factory.py
@@ -85,6 +85,7 @@ class VLMProviderFactory:
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         """
         Generate an explanation using the specified provider.
@@ -97,6 +98,9 @@ class VLMProviderFactory:
             gradcam_available: Whether a real heatmap was generated
             region_image_bytes: Zoomed-in crop images for each detected region,
                                  sent to the VLM for close-up artifact inspection
+            ela_bytes: Optional ELA overlay PNG bytes — passed alongside
+                       detection.forensics_report so the VLM has both the
+                       visual map and the per-region z-scores.
         """
         resolved_id = provider_id or self._config.default_provider
 
@@ -127,6 +131,7 @@ class VLMProviderFactory:
             detection,
             gradcam_available=gradcam_available,
             region_image_bytes=region_image_bytes,
+            ela_bytes=ela_bytes,
         )
 
         if resolved_id != "mock":

--- a/backend/app/services/vlm/prompt_builder.py
+++ b/backend/app/services/vlm/prompt_builder.py
@@ -12,17 +12,22 @@ template ensures explanations are:
 5. Grounded via few-shot examples to establish tone and style
 """
 
+from app.services.categories import FACE_CATEGORIES
 from app.services.vlm.base import DetectionContext
 
 SYSTEM_PROMPT_WITH_GRADCAM = """You are a forensic image analyst explaining deepfake detection results \
 to everyday users with no technical background.
 
-You will receive images in this order:
-- Image 1: The original photo that was analyzed
-- Image 2: A GradCAM heatmap overlay. Warmer and brighter colors (red, orange, yellow) show \
+You will receive several images. The user message states the exact position of \
+each one. Possible image types:
+- The ORIGINAL photo that was analyzed.
+- A GRADCAM HEATMAP overlay. Warmer/brighter colors (red, orange, yellow) show \
 which regions the AI detection model paid most attention to.
-- Images 3, 4, 5 (if present): Zoomed-in crops of the specific facial regions, in order from \
-highest to lowest activation. Study these carefully — they are the primary evidence.
+- An ELA (Error Level Analysis) MAP overlay. Bright red/yellow pixels show \
+areas with anomalously high JPEG re-compression residuals — a forensic signal \
+that often spikes near generated, blended, or otherwise manipulated regions.
+- Zoomed-in CROPS of specific facial regions, in order from highest to lowest \
+activation. Study these carefully — they are the primary visual evidence.
 
 LENGTH RULES — follow these strictly:
 - [SUMMARY]: 1 sentence. State what was found and where. Nothing more.
@@ -43,6 +48,13 @@ highlight it. Label it clearly (e.g. "Hair and eyebrows", "Left eye", "Skin tone
 - Aim to comment on at least 3 distinct facial areas total, mixing GradCAM regions and your \
 own observations from the full photo.
 - If the image is classified as real, scan the same areas and note what looks natural.
+
+GROUNDING RULE — applies whenever a [FORENSIC EVIDENCE] block is provided:
+- Every claim in [REGIONS] must reference EITHER (a) a specific visual cue \
+you can see in that region's crop or in the ELA map, OR (b) a forensic metric \
+from the [FORENSIC EVIDENCE] block, cited by name (e.g. "the sharpness z-score \
+of -3.8" or "the ELA peak in the mouth area"). Do not invent metrics. Do not \
+contradict the numbers in the evidence block.
 
 QUALITY RULES:
 - Every sentence must reference something you can actually see, not a general pattern
@@ -143,10 +155,122 @@ Use the [SUMMARY], [DETAILED], [TECHNICAL], [REGIONS] format exactly."""
 SYSTEM_PROMPT = SYSTEM_PROMPT_WITH_GRADCAM
 
 
+# Threshold below which a metric z-score is treated as "within real-face range"
+# and gets a brief, non-suspicious description.
+_NOTABLE_Z = 1.0
+# Cap on how many regions appear in the [FORENSIC EVIDENCE] block. Keeps the
+# block short so the VLM can scan the numbers quickly (target ≲ 10 lines).
+_MAX_FORENSIC_ROWS = 6
+
+
+def _describe_metric(metric: str, z: float) -> str:
+    """Return a short ``"label z=±X.X (descriptor)"`` fragment for one metric.
+
+    The descriptors are tuned to nudge the VLM toward forensically-correct
+    interpretations: low sharpness on a face usually means over-smoothing,
+    high HF energy often signals upsampling/GAN textures, and a high ELA
+    intensity on a region indicates the region was re-encoded differently
+    from its surroundings (a classic compositing tell).
+    """
+    if metric == "laplacian_variance":
+        if abs(z) < _NOTABLE_Z:
+            descr = "within real-face range"
+        elif z < 0:
+            descr = "unusually smooth"
+        else:
+            descr = "unusually sharp"
+        return f"sharpness z={z:+.1f} ({descr})"
+    if metric == "hf_energy":
+        if abs(z) < _NOTABLE_Z:
+            descr = "within real-face range"
+        elif z > 0:
+            descr = "upsampling artifacts likely"
+        else:
+            descr = "high-freq deficit"
+        return f"high-freq energy z={z:+.1f} ({descr})"
+    if metric == "ela_intensity":
+        if abs(z) < _NOTABLE_Z:
+            descr = "within real-face range"
+        elif z > 0:
+            descr = f"ELA peak {abs(z):.1f}σ above face mean"
+        else:
+            descr = "low ELA residual"
+        return f"ELA intensity z={z:+.1f} ({descr})"
+    return f"{metric} z={z:+.1f}"
+
+
+def build_forensic_evidence_block(detection: DetectionContext) -> str:
+    """Render the optional ``[FORENSIC EVIDENCE]`` block from forensics_report.
+
+    Each row lists the per-region z-scores for sharpness, high-frequency
+    energy, and ELA intensity. Metrics with ``|z| < 1`` are dropped per
+    region (or kept as a single "within real-face range" line when none of
+    the three are notable) so the block stays scannable.
+
+    Returns an empty string when ``detection.forensics_report`` is None or
+    the reference distribution cannot be loaded — keeping the prompt fully
+    backwards-compatible.
+    """
+    report = detection.forensics_report
+    if report is None or not report.regions:
+        return ""
+
+    # Local import keeps the module importable when the reference distribution
+    # is absent (e.g. in unit tests that don't ship real_distribution.json).
+    try:
+        from app.services.forensics import z_score
+    except Exception:
+        return ""
+
+    rows: list[tuple[str, float]] = []  # (line_text, max_abs_z)
+    for cat_id, region in report.regions.items():
+        face_cat = FACE_CATEGORIES.get(cat_id)
+        if face_cat is None:
+            continue
+
+        try:
+            z_by_metric = {
+                "laplacian_variance": z_score(
+                    cat_id, "laplacian_variance", region.laplacian_variance
+                ),
+                "hf_energy": z_score(cat_id, "hf_energy", region.hf_energy),
+                "ela_intensity": z_score(cat_id, "ela_intensity", region.ela_intensity),
+            }
+        except RuntimeError:
+            # real_distribution.json missing — skip the block entirely so the
+            # VLM doesn't see a half-rendered evidence list.
+            return ""
+
+        notable = [
+            _describe_metric(metric, z) for metric, z in z_by_metric.items() if abs(z) >= _NOTABLE_Z
+        ]
+        max_abs_z = max((abs(z) for z in z_by_metric.values()), default=0.0)
+
+        if not notable:
+            # Keep the row but mark it as benign so the VLM knows this region
+            # was checked and found unremarkable.
+            line = f"{face_cat.label} — within real-face range across all metrics"
+        else:
+            line = f"{face_cat.label} — " + ", ".join(notable)
+
+        rows.append((line, max_abs_z))
+
+    if not rows:
+        return ""
+
+    # Surface the most anomalous regions first so the VLM's attention lands
+    # on them; drop the long tail to keep the block compact.
+    rows.sort(key=lambda r: r[1], reverse=True)
+    top = rows[:_MAX_FORENSIC_ROWS]
+
+    return "[FORENSIC EVIDENCE]\n" + "\n".join(line for line, _ in top)
+
+
 def build_explanation_prompt(
     detection: DetectionContext,
     gradcam_available: bool = True,
     region_count: int = 0,
+    ela_available: bool = False,
 ) -> str:
     """
     Build the user-facing prompt with detection context and region labels.
@@ -172,29 +296,66 @@ def build_explanation_prompt(
     fake_prob = detection.probabilities.get("fake", 0)
     real_prob = detection.probabilities.get("real", 0)
 
-    # Build the image layout description so the VLM knows exactly which image is which
-    crop_image_start = 3 if gradcam_available else 2
+    # Image positions are dynamic — original is always image 1, then GradCAM
+    # and ELA are inserted in that order when available, then region crops.
+    next_idx = 2
+    layout_lines: list[str] = ["Image 1: the original photo."]
+
+    gradcam_idx = None
     if gradcam_available:
-        if region_count > 0:
-            crop_refs = ", ".join(f"Image {crop_image_start + i}" for i in range(region_count))
-            image_instruction = (
-                f"Look at the GradCAM heatmap (Image 2) to see which areas the model focused on, "
-                f"then examine the zoomed-in region crops ({crop_refs}) to inspect each area up close. "
-                f"Describe the specific visual details you actually see in the crops — texture, edges, "
-                f"blending, skin quality — that support or contradict this classification."
-            )
-        else:
-            image_instruction = (
-                "Look at the GradCAM heatmap (Image 2) and describe what you observe "
-                "in the highlighted regions of the original photo (Image 1). "
-                "What specific visual details in those regions support this classification?"
-            )
+        gradcam_idx = next_idx
+        layout_lines.append(f"Image {gradcam_idx}: the GradCAM heatmap overlay.")
+        next_idx += 1
+
+    ela_idx = None
+    if ela_available:
+        ela_idx = next_idx
+        layout_lines.append(
+            f"Image {ela_idx}: the ELA (Error Level Analysis) overlay — "
+            "bright red/yellow pixels mark areas with anomalously high JPEG "
+            "re-compression residuals."
+        )
+        next_idx += 1
+
+    crop_image_start = next_idx
+    if region_count > 0:
+        crop_refs = ", ".join(str(crop_image_start + i) for i in range(region_count))
+        plural = "Images" if region_count > 1 else "Image"
+        layout_lines.append(
+            f"{plural} {crop_refs}: zoomed-in crops of facial regions, ordered "
+            "from highest to lowest activation."
+        )
+
+    if gradcam_available and region_count > 0:
+        cite_clauses = [f"the GradCAM heatmap (Image {gradcam_idx})"]
+        if ela_idx is not None:
+            cite_clauses.append(f"the ELA map (Image {ela_idx})")
+        cite_text = " and ".join(cite_clauses)
+        image_instruction = (
+            f"Look at {cite_text} to see where the model and the forensic "
+            f"signals point, then examine each region crop up close. Describe "
+            f"the specific visual details you actually see in the crops — "
+            f"texture, edges, blending, skin quality — that support or "
+            f"contradict this classification."
+        )
+    elif gradcam_available:
+        cite_clauses = [f"the GradCAM heatmap (Image {gradcam_idx})"]
+        if ela_idx is not None:
+            cite_clauses.append(f"the ELA map (Image {ela_idx})")
+        cite_text = " and ".join(cite_clauses)
+        image_instruction = (
+            f"Look at {cite_text} and describe what you observe in the "
+            "highlighted regions of the original photo (Image 1). What "
+            "specific visual details there support this classification?"
+        )
     else:
         image_instruction = (
             "The GradCAM heatmap is not available for this analysis. "
             "Look at the original photo and describe what visual features "
             "you can directly observe that support or contradict this classification."
         )
+
+    layout_block = "Image layout:\n" + "\n".join(f"- {line}" for line in layout_lines)
 
     regions_instruction = ""
 
@@ -233,13 +394,18 @@ def build_explanation_prompt(
             f"{labels_list}"
         )
 
+    forensic_block = build_forensic_evidence_block(detection)
+    forensic_section = f"\n\n{forensic_block}" if forensic_block else ""
+
     prompt = f"""Here are the detection results for the image.
 
 Detection result: {classification} ({confidence_pct} confidence)
 Fake probability: {fake_prob:.1%} | Real probability: {real_prob:.1%}
 Model: {detection.model_used}
 
-{image_instruction}{regions_instruction}
+{layout_block}
+
+{image_instruction}{forensic_section}{regions_instruction}
 
 Use the [SUMMARY], [DETAILED], [TECHNICAL], [REGIONS] format."""
 

--- a/backend/app/services/vlm/providers/anthropic.py
+++ b/backend/app/services/vlm/providers/anthropic.py
@@ -37,9 +37,11 @@ class AnthropicProvider(BaseVLMProvider):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         start_time = time.time()
         regions = region_image_bytes or []
+        ela_available = ela_bytes is not None
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
@@ -48,6 +50,7 @@ class AnthropicProvider(BaseVLMProvider):
             detection,
             gradcam_available=gradcam_available,
             region_count=len(regions),
+            ela_available=ela_available,
         )
 
         image_b64 = base64.b64encode(image_bytes).decode("utf-8")
@@ -71,6 +74,18 @@ class AnthropicProvider(BaseVLMProvider):
                         "type": "base64",
                         "media_type": "image/png",
                         "data": heatmap_b64,
+                    },
+                }
+            )
+        if ela_available:
+            ela_b64 = base64.b64encode(ela_bytes).decode("utf-8")
+            content.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": ela_b64,
                     },
                 }
             )

--- a/backend/app/services/vlm/providers/gemini.py
+++ b/backend/app/services/vlm/providers/gemini.py
@@ -40,11 +40,13 @@ class GeminiProvider(BaseVLMProvider):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         import asyncio
 
         start_time = time.time()
         regions = region_image_bytes or []
+        ela_available = ela_bytes is not None
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
@@ -53,6 +55,7 @@ class GeminiProvider(BaseVLMProvider):
             detection,
             gradcam_available=gradcam_available,
             region_count=len(regions),
+            ela_available=ela_available,
         )
 
         try:
@@ -62,6 +65,8 @@ class GeminiProvider(BaseVLMProvider):
             ]
             if gradcam_available:
                 contents.append(types.Part.from_bytes(data=heatmap_bytes, mime_type="image/png"))
+            if ela_available:
+                contents.append(types.Part.from_bytes(data=ela_bytes, mime_type="image/png"))
             for region_bytes in regions:
                 contents.append(types.Part.from_bytes(data=region_bytes, mime_type="image/jpeg"))
 

--- a/backend/app/services/vlm/providers/mock.py
+++ b/backend/app/services/vlm/providers/mock.py
@@ -92,6 +92,7 @@ class MockProvider(BaseVLMProvider):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         """Return a mock explanation based on the detection classification."""
 

--- a/backend/app/services/vlm/providers/openai.py
+++ b/backend/app/services/vlm/providers/openai.py
@@ -40,9 +40,11 @@ class OpenAIProvider(BaseVLMProvider):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         start_time = time.time()
         regions = region_image_bytes or []
+        ela_available = ela_bytes is not None
 
         system_prompt = (
             SYSTEM_PROMPT_WITH_GRADCAM if gradcam_available else SYSTEM_PROMPT_WITHOUT_GRADCAM
@@ -51,6 +53,7 @@ class OpenAIProvider(BaseVLMProvider):
             detection,
             gradcam_available=gradcam_available,
             region_count=len(regions),
+            ela_available=ela_available,
         )
 
         image_b64 = base64.b64encode(image_bytes).decode("utf-8")
@@ -64,6 +67,9 @@ class OpenAIProvider(BaseVLMProvider):
             content.append(
                 {"type": "input_image", "image_url": f"data:image/png;base64,{heatmap_b64}"}
             )
+        if ela_available:
+            ela_b64 = base64.b64encode(ela_bytes).decode("utf-8")
+            content.append({"type": "input_image", "image_url": f"data:image/png;base64,{ela_b64}"})
         for region_bytes in regions:
             region_b64 = base64.b64encode(region_bytes).decode("utf-8")
             content.append(

--- a/backend/app/services/vlm/providers/rule_based.py
+++ b/backend/app/services/vlm/providers/rule_based.py
@@ -399,6 +399,7 @@ class RuleBasedProvider(BaseVLMProvider):
         detection: DetectionContext,
         gradcam_available: bool = True,
         region_image_bytes: list[bytes] | None = None,
+        ela_bytes: bytes | None = None,
     ) -> VLMExplanation:
         start = time.time()
 

--- a/backend/scripts/generate_sg3.py
+++ b/backend/scripts/generate_sg3.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import argparse
 import io
-import os
 import pickle
 import subprocess
 import sys

--- a/backend/tests/test_prompt_builder.py
+++ b/backend/tests/test_prompt_builder.py
@@ -8,8 +8,14 @@ silently drops per-region explanations in the UI.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+from app.services.forensics.report import ForensicsReport, RegionForensics
+from app.services.vlm.base import DetectionContext
 from app.services.vlm.prompt_builder import (
     _parse_region_comments,
+    build_explanation_prompt,
+    build_forensic_evidence_block,
     parse_explanation_response,
 )
 
@@ -55,6 +61,178 @@ class TestParseRegionComments:
         text = "Some intro text\nSkin Texture | Looks waxy.\nMore text"
         result = _parse_region_comments(text)
         assert result == {"Skin Texture": "Looks waxy."}
+
+
+def _make_detection(
+    forensics_report: ForensicsReport | None = None,
+) -> DetectionContext:
+    """Build a minimal DetectionContext for prompt-builder tests."""
+    return DetectionContext(
+        classification="fake",
+        confidence=0.92,
+        model_used="EfficientNet-B4",
+        probabilities={"fake": 0.92, "real": 0.08},
+        region_labels=[],
+        region_categories=[],
+        forensics_report=forensics_report,
+    )
+
+
+def _z_score_stub(region: str, metric: str, value: float) -> float:
+    """Map raw metric values into z-scores deterministically for tests.
+
+    The stub treats the raw value AS the z-score so each test case can
+    construct a ``RegionForensics`` with the desired z directly.
+    """
+    return float(value)
+
+
+class TestBuildForensicEvidenceBlock:
+    def test_empty_when_no_report(self):
+        assert build_forensic_evidence_block(_make_detection(None)) == ""
+
+    def test_empty_when_report_has_no_regions(self):
+        report = ForensicsReport(regions={}, image_size=(0, 0))
+        assert build_forensic_evidence_block(_make_detection(report)) == ""
+
+    def test_block_renders_notable_metrics(self):
+        report = ForensicsReport(
+            regions={
+                "skin_texture": RegionForensics(
+                    laplacian_variance=-3.8,
+                    hf_energy=2.1,
+                    ela_intensity=0.2,
+                ),
+                "mouth_teeth": RegionForensics(
+                    laplacian_variance=0.1,
+                    hf_energy=0.0,
+                    ela_intensity=2.9,
+                ),
+                "eyes_pupils": RegionForensics(
+                    laplacian_variance=-0.2,
+                    hf_energy=0.3,
+                    ela_intensity=-0.1,
+                ),
+            },
+            image_size=(512, 512),
+        )
+
+        with patch(
+            "app.services.forensics.z_score",
+            side_effect=_z_score_stub,
+        ):
+            block = build_forensic_evidence_block(_make_detection(report))
+
+        assert block.startswith("[FORENSIC EVIDENCE]")
+        assert "Skin Texture" in block
+        assert "sharpness z=-3.8 (unusually smooth)" in block
+        assert "high-freq energy z=+2.1 (upsampling artifacts likely)" in block
+        assert "Mouth & Teeth" in block
+        assert "ELA peak 2.9σ above face mean" in block
+        # Eyes were entirely within real-face range — should be summarised.
+        assert "Eyes & Pupils — within real-face range across all metrics" in block
+
+    def test_rows_sorted_by_max_abs_z(self):
+        """The most anomalous region must appear first so the VLM sees it."""
+        report = ForensicsReport(
+            regions={
+                "skin_texture": RegionForensics(
+                    laplacian_variance=-1.2,
+                    hf_energy=0.0,
+                    ela_intensity=0.0,
+                ),
+                "mouth_teeth": RegionForensics(
+                    laplacian_variance=0.0,
+                    hf_energy=0.0,
+                    ela_intensity=3.5,
+                ),
+            },
+            image_size=(512, 512),
+        )
+
+        with patch(
+            "app.services.forensics.z_score",
+            side_effect=_z_score_stub,
+        ):
+            block = build_forensic_evidence_block(_make_detection(report))
+
+        skin_idx = block.index("Skin Texture")
+        mouth_idx = block.index("Mouth & Teeth")
+        assert mouth_idx < skin_idx, "Most anomalous region should rank first"
+
+    def test_block_returns_empty_when_distribution_missing(self):
+        """Graceful fallback so unit envs without real_distribution.json work."""
+        report = ForensicsReport(
+            regions={
+                "skin_texture": RegionForensics(
+                    laplacian_variance=-3.0, hf_energy=0.0, ela_intensity=0.0
+                ),
+            },
+            image_size=(512, 512),
+        )
+
+        def raises(*_a, **_k):
+            raise RuntimeError("real_distribution.json not found")
+
+        with patch("app.services.forensics.z_score", side_effect=raises):
+            assert build_forensic_evidence_block(_make_detection(report)) == ""
+
+
+class TestBuildExplanationPromptForensicWiring:
+    def test_no_forensic_block_when_report_is_none(self):
+        prompt = build_explanation_prompt(
+            _make_detection(None),
+            gradcam_available=True,
+            region_count=2,
+            ela_available=False,
+        )
+        assert "[FORENSIC EVIDENCE]" not in prompt
+
+    def test_image_layout_lists_ela_when_available(self):
+        prompt = build_explanation_prompt(
+            _make_detection(None),
+            gradcam_available=True,
+            region_count=2,
+            ela_available=True,
+        )
+        # Expect: Image 1 = original, Image 2 = GradCAM, Image 3 = ELA, Images 4, 5 = crops
+        assert "Image 1: the original photo." in prompt
+        assert "Image 2: the GradCAM heatmap overlay." in prompt
+        assert "Image 3: the ELA" in prompt
+        assert "Images 4, 5:" in prompt
+
+    def test_image_layout_omits_ela_when_unavailable(self):
+        prompt = build_explanation_prompt(
+            _make_detection(None),
+            gradcam_available=True,
+            region_count=2,
+            ela_available=False,
+        )
+        # Crops should follow GradCAM directly.
+        assert "the ELA" not in prompt
+        assert "Images 3, 4:" in prompt
+
+    def test_forensic_block_appears_when_report_provided(self):
+        report = ForensicsReport(
+            regions={
+                "skin_texture": RegionForensics(
+                    laplacian_variance=-3.8, hf_energy=0.0, ela_intensity=0.0
+                ),
+            },
+            image_size=(512, 512),
+        )
+        with patch(
+            "app.services.forensics.z_score",
+            side_effect=_z_score_stub,
+        ):
+            prompt = build_explanation_prompt(
+                _make_detection(report),
+                gradcam_available=True,
+                region_count=0,
+                ela_available=True,
+            )
+        assert "[FORENSIC EVIDENCE]" in prompt
+        assert "sharpness z=-3.8" in prompt
 
 
 class TestParseExplanationResponse:


### PR DESCRIPTION
Implements roadmap issue #6 / GitHub #84 — the VLM now describes *measured*
forensic evidence instead of confabulating from the heatmap alone.

## Summary

- `DetectionContext.forensics_report: ForensicsReport | None` — new field
- `[FORENSIC EVIDENCE]` block rendered in the user prompt, sorted by max
  abs z-score, ≤ 6 rows, with descriptors like *unusually smooth*,
  *upsampling artifacts likely*, *ELA peak Xσ above face mean*
- ELA overlay image (red/yellow hot-colormap on the original, mirroring
  the GradCAM overlay pattern) sent to the VLM after the GradCAM heatmap
  and before the region crops
- System prompt rewritten so image *positions* are stated per-call by the
  user message, not hard-coded; new GROUNDING RULE: every `[REGIONS]`
  claim must reference a visible crop cue **or** cite a forensic metric
  by name
- All five providers (Anthropic / OpenAI / Gemini / mock / rule_based) +
  the factory accept `ela_bytes`
- `_build_ranked_evidence` returns the `ForensicsReport` so it can be
  reused by the VLM prompt even when no region clears the suspicion
  threshold

## Acceptance criteria

- [x] `DetectionContext` gains `forensics_report` field
- [x] Prompt emits `[FORENSIC EVIDENCE]` block in the example shape
- [x] VLM receives the ELA overlay (after GradCAM, before crops)
- [x] System prompt instructs grounding to crop visuals or named metrics
- [x] Backwards-compatible when `forensics_report is None`

## Sample rendered prompt

Image layout:

Image 1: the original photo.
Image 2: the GradCAM heatmap overlay.
Image 3: the ELA (Error Level Analysis) overlay — bright red/yellow pixels mark ...
Images 4, 5: zoomed-in crops of facial regions, ordered from highest to lowest activation.
[FORENSIC EVIDENCE]
Skin Texture — sharpness z=-3.8 (unusually smooth), high-freq energy z=+2.1 (upsampling artifacts likely)
Mouth & Teeth — ELA intensity z=+2.9 (ELA peak 2.9σ above face mean)
Eyes & Pupils — within real-face range across all metrics



## Test plan

- [x] `pytest tests/` — 83 passed, 1 skipped (10 new tests for the
      forensic block + image layout wiring + backwards-compat)
- [x] `ruff check app/ tests/` — clean
- [x] Verified prompt renders cleanly with `forensics_report=None`
- [x] Manual smoke test against one real provider on a study image
      before merging

Closes #84