### PR TITLE
feat(vlm): structured JSON output with per-claim evidence tagging (#85)

### DIFF
--- a/backend/app/routers/analyses.py
+++ b/backend/app/routers/analyses.py
@@ -61,6 +61,12 @@ class EvidenceRegion(BaseModel):
     forensic_score: float | None = None
     suspicion_score: float | None = None
     z_scores: dict[str, float] | None = None
+    # Populated when the VLM returned a structured per-claim record
+    # (structured_regions). Optional so older analyses persisted before this
+    # field existed continue to deserialise.
+    evidence_type: str | None = None
+    evidence_ref: str | None = None
+    claim_confidence: float | None = None
 
 
 class AnalysisResponse(BaseModel):
@@ -297,20 +303,50 @@ def _build_ranked_evidence(
 def _attach_region_comments(
     evidence_regions: list[dict],
     region_comments: dict,
+    structured_regions: list[dict] | None = None,
 ) -> list[dict]:
-    """
-    Attach VLM region comments to evidence region dicts by matching label.
+    """Attach VLM region comments and per-claim evidence tags to evidence regions.
 
-    Args:
-        evidence_regions: List of dicts with url, label, activation_score.
-        region_comments: Dict mapping label -> one-sentence explanation.
+    The flat ``region_comments`` dict (label → one-sentence explanation) is
+    used to populate ``explanation`` for backwards compatibility. When
+    ``structured_regions`` is provided, each entry's ``observation``
+    additionally overrides the explanation (it carries the same text under
+    the structured schema), and ``evidence_type``, ``evidence_ref``, and
+    ``claim_confidence`` are attached for the frontend to highlight cited
+    metrics or heatmap regions.
 
-    Returns:
-        Evidence regions with explanation field populated where available.
+    Matching is by region label, with case- and whitespace-insensitive
+    fallback so minor casing drift between provider output and our region
+    labels does not silently drop the tag.
     """
+    structured_by_label: dict[str, dict] = {}
+    if structured_regions:
+        for record in structured_regions:
+            label = (record.get("region") or "").strip()
+            if label:
+                structured_by_label[label.lower()] = record
+
     for region in evidence_regions:
         label = region.get("label", "")
         region["explanation"] = region_comments.get(label, None)
+
+        record = structured_by_label.get(label.strip().lower())
+        if record is None:
+            continue
+        # Prefer the structured observation when present — the legacy
+        # region_comments dict was derived from the same field for VLM
+        # providers that took the JSON path.
+        observation = record.get("observation")
+        if observation:
+            region["explanation"] = observation
+        region["evidence_type"] = record.get("evidence_type")
+        region["evidence_ref"] = record.get("evidence_ref")
+        confidence = record.get("confidence")
+        if confidence is not None:
+            try:
+                region["claim_confidence"] = float(confidence)
+            except (TypeError, ValueError):
+                pass
     return evidence_regions
 
 
@@ -609,11 +645,16 @@ async def create_analysis(request: AnalysisRequest):
                     print("VLM raw response:", vlm_explanation.raw_response)
                     print("Region comments parsed:", vlm_explanation.region_comments)
 
-                    # Attach per-region comments to evidence crops
-                    if vlm_explanation.region_comments and evidence_regions:
+                    # Attach per-region comments + structured evidence tags
+                    # to evidence crops. structured_regions is None when the
+                    # provider fell back to the legacy free-text path.
+                    if (
+                        vlm_explanation.region_comments or vlm_explanation.structured_regions
+                    ) and evidence_regions:
                         evidence_regions = _attach_region_comments(
                             evidence_regions,
-                            vlm_explanation.region_comments,
+                            vlm_explanation.region_comments or {},
+                            structured_regions=vlm_explanation.structured_regions,
                         )
 
                     explanation_data = ExplanationData(

--- a/backend/app/services/vlm/base.py
+++ b/backend/app/services/vlm/base.py
@@ -25,6 +25,13 @@ class VLMExplanation:
     # e.g. {"Nose and mid-face region": "The bright red activation here..."}
     region_comments: Optional[dict] = None
 
+    # Per-region structured records when the provider used the JSON-schema
+    # path. Each entry has keys: region, observation, evidence_type
+    # ("visual" | "metric" | "heatmap"), evidence_ref, confidence. Surfaced
+    # alongside region_comments so the frontend can show per-claim evidence
+    # tags without breaking callers that only consume region_comments.
+    structured_regions: Optional[list[dict]] = None
+
     provider: str = ""
     model: str = ""
     processing_time_ms: int = 0

--- a/backend/app/services/vlm/prompt_builder.py
+++ b/backend/app/services/vlm/prompt_builder.py
@@ -12,8 +12,14 @@ template ensures explanations are:
 5. Grounded via few-shot examples to establish tone and style
 """
 
+import json
+import logging
+
 from app.services.categories import FACE_CATEGORIES
 from app.services.vlm.base import DetectionContext
+from app.services.vlm.structured_schema import EVIDENCE_TYPES
+
+logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT_WITH_GRADCAM = """You are a forensic image analyst explaining deepfake detection results \
 to everyday users with no technical background.
@@ -153,6 +159,194 @@ Use the [SUMMARY], [DETAILED], [TECHNICAL], [REGIONS] format exactly."""
 
 # Alias for backwards compatibility
 SYSTEM_PROMPT = SYSTEM_PROMPT_WITH_GRADCAM
+
+
+SYSTEM_PROMPT_STRUCTURED = """You are a forensic image analyst explaining deepfake detection results \
+to everyday users with no technical background. You return your answer as a \
+SINGLE structured JSON object — no preamble, no Markdown.
+
+You will receive several images. The user message states the exact position of \
+each one. Possible image types:
+- The ORIGINAL photo that was analyzed.
+- A GRADCAM HEATMAP overlay. Warmer/brighter colors show which regions the AI \
+detection model paid most attention to.
+- An ELA (Error Level Analysis) MAP overlay. Bright red/yellow pixels show \
+areas with anomalously high JPEG re-compression residuals.
+- Zoomed-in CROPS of specific facial regions, ordered from highest to lowest \
+activation.
+
+Your output must conform to this shape:
+
+{
+  "summary": "<one sentence>",
+  "detailed_analysis": "<two to three sentences>",
+  "technical_notes": "<three to five short lines>",
+  "regions": [
+    {
+      "region": "<exact label from the [REGIONS] list>",
+      "observation": "<one to three sentences of specific visual or measured detail>",
+      "evidence_type": "visual" | "metric" | "heatmap",
+      "evidence_ref": "<specific anchor — see rules below>",
+      "confidence": <number in [0, 1]>
+    }
+  ]
+}
+
+EVIDENCE GROUNDING — non-negotiable:
+- Every region object must tag its evidence_type and provide an evidence_ref.
+- "visual" → cite the crop or photo area, e.g. "left jaw crop" or "skin near \
+the cheekbone in Image 1".
+- "metric" → cite a metric from the [FORENSIC EVIDENCE] block by name and \
+value, e.g. "sharpness_z=-3.8" or "ela_intensity_z=+2.9 in Mouth & Teeth".
+- "heatmap" → cite a pattern visible in the GradCAM or ELA overlay, e.g. \
+"GradCAM peak around the mouth" or "ELA hotspot on the jawline".
+- evidence_ref MAY be empty only when no specific anchor exists. If you set \
+confidence above 0.7 you MUST provide a non-empty evidence_ref.
+
+CONTENT RULES:
+- summary: one sentence stating what was found and where.
+- detailed_analysis: two to three sentences. The single most distinctive cue. \
+No filler like "consistent with" or "strongly supports".
+- technical_notes: three to five short lines. May reference activation \
+percentages, z-scores, or model confidence.
+- regions: cover at least every entry in the user's [REGIONS] list. You may \
+add extra entries if you spotted something noteworthy outside the heatmap. \
+Each observation must describe something specific, not a generic pattern.
+- Plain everyday language in summary, detailed_analysis, observations.
+- Forbidden phrases: "composite artifact", "synthetic", "indicates \
+manipulation", "consistent with", "strongly suggests", "digital alteration", \
+"forensic" (the word — but the metric names from the evidence block are fine).
+
+Return ONLY the JSON object."""
+
+
+def parse_structured_response(payload: object) -> dict | None:
+    """Validate and normalise a structured VLM response.
+
+    Accepts either a dict (already-parsed JSON, the common case for tool-use
+    and json_schema modes) or a raw string (we parse it as JSON). Returns a
+    normalised dict on success, or ``None`` on outright validation failure
+    (malformed JSON, missing required field, wrong type, unknown
+    evidence_type) — the caller uses ``None`` as the signal to retry once
+    or fall back to free-text parsing.
+
+    "Soft" issues — confidence > 0.7 with empty evidence_ref, confidence
+    outside [0, 1] — are clamped or logged but not treated as failures, so
+    we don't burn a second VLM call on something that's still useful.
+    """
+    if payload is None:
+        return None
+
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            logger.warning("Structured response is not valid JSON: %s", exc)
+            return None
+
+    if not isinstance(payload, dict):
+        logger.warning("Structured response is not a JSON object: %r", type(payload))
+        return None
+
+    required_top = ("summary", "detailed_analysis", "technical_notes", "regions")
+    missing = [k for k in required_top if k not in payload]
+    if missing:
+        logger.warning("Structured response missing required keys: %s", missing)
+        return None
+
+    if not isinstance(payload["regions"], list):
+        logger.warning("Structured response 'regions' is not a list")
+        return None
+
+    cleaned_regions: list[dict] = []
+    for idx, region in enumerate(payload["regions"]):
+        normalised = _normalise_region(region, idx)
+        if normalised is None:
+            return None
+        cleaned_regions.append(normalised)
+
+    return {
+        "summary": str(payload["summary"]).strip(),
+        "detailed_analysis": str(payload["detailed_analysis"]).strip(),
+        "technical_notes": str(payload["technical_notes"]).strip(),
+        "regions": cleaned_regions,
+    }
+
+
+def _normalise_region(region: object, idx: int) -> dict | None:
+    """Validate one region object; return ``None`` on hard failure."""
+    if not isinstance(region, dict):
+        logger.warning("Region #%d is not an object: %r", idx, type(region))
+        return None
+
+    required = ("region", "observation", "evidence_type", "evidence_ref", "confidence")
+    missing = [k for k in required if k not in region]
+    if missing:
+        logger.warning("Region #%d missing keys: %s", idx, missing)
+        return None
+
+    evidence_type = str(region["evidence_type"]).strip().lower()
+    if evidence_type not in EVIDENCE_TYPES:
+        logger.warning(
+            "Region #%d has unknown evidence_type %r (allowed: %s)",
+            idx,
+            evidence_type,
+            EVIDENCE_TYPES,
+        )
+        return None
+
+    try:
+        confidence = float(region["confidence"])
+    except (TypeError, ValueError):
+        logger.warning("Region #%d confidence is not numeric: %r", idx, region["confidence"])
+        return None
+
+    # Soft-clamp out-of-range confidence rather than failing — the prose is
+    # still useful and we'd rather not burn a second VLM call.
+    if not 0.0 <= confidence <= 1.0:
+        logger.info(
+            "Region #%d confidence %.3f out of [0, 1]; clamping",
+            idx,
+            confidence,
+        )
+        confidence = max(0.0, min(1.0, confidence))
+
+    label = _normalise_region_label(str(region["region"]))
+    observation = str(region["observation"]).strip()
+    evidence_ref = str(region["evidence_ref"]).strip()
+
+    # Soft check: a high-confidence claim with no anchor is the failure mode
+    # the schema is meant to prevent, but we don't fail validation over it —
+    # the providers log + keep the claim. The frontend can flag it.
+    if confidence > 0.7 and not evidence_ref:
+        logger.warning(
+            "Region %r has confidence %.2f but empty evidence_ref",
+            label,
+            confidence,
+        )
+
+    return {
+        "region": label,
+        "observation": observation,
+        "evidence_type": evidence_type,
+        "evidence_ref": evidence_ref,
+        "confidence": confidence,
+    }
+
+
+def structured_to_legacy(parsed: dict) -> dict[str, object]:
+    """Convert a validated structured response into the flat shape used by
+    today's parser, so providers and ``analyses.py`` can consume both paths
+    uniformly. The richer per-region fields are surfaced separately via
+    :class:`VLMExplanation.structured_regions`.
+    """
+    region_comments = {r["region"]: r["observation"] for r in parsed["regions"]}
+    return {
+        "summary": parsed["summary"],
+        "detailed_analysis": parsed["detailed_analysis"],
+        "technical_notes": parsed["technical_notes"],
+        "region_comments": region_comments,
+    }
 
 
 # Threshold below which a metric z-score is treated as "within real-face range"

--- a/backend/app/services/vlm/providers/anthropic.py
+++ b/backend/app/services/vlm/providers/anthropic.py
@@ -11,11 +11,15 @@ import anthropic
 from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInfo, VLMExplanation
 from app.services.vlm.config import ProviderConfig
 from app.services.vlm.prompt_builder import (
+    SYSTEM_PROMPT_STRUCTURED,
     SYSTEM_PROMPT_WITH_GRADCAM,
     SYSTEM_PROMPT_WITHOUT_GRADCAM,
     build_explanation_prompt,
     parse_explanation_response,
+    parse_structured_response,
+    structured_to_legacy,
 )
+from app.services.vlm.structured_schema import anthropic_tool_definition
 
 logger = logging.getLogger(__name__)
 
@@ -104,21 +108,85 @@ class AnthropicProvider(BaseVLMProvider):
         content.append({"type": "text", "text": user_prompt})
 
         try:
+            # Preferred path: tool-use forces the model to call our schema tool
+            # so the response is JSON we can validate. On hard validation
+            # failure we fall through to the legacy free-text path so a
+            # malformed structured reply never breaks user-facing output.
+            tool = anthropic_tool_definition()
             response = self._client.messages.create(
                 model=self._model,
-                system=system_prompt,
+                system=SYSTEM_PROMPT_STRUCTURED if gradcam_available else system_prompt,
                 messages=[{"role": "user", "content": content}],
                 max_tokens=2000,
                 temperature=0.3,
+                tools=[tool],
+                tool_choice={"type": "tool", "name": tool["name"]},
             )
-
-            raw_text = response.content[0].text if response.content else ""
-            processing_time = int((time.time() - start_time) * 1000)
 
             input_tokens = response.usage.input_tokens if response.usage else None
             output_tokens = response.usage.output_tokens if response.usage else None
-
             estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+
+            structured_payload = _extract_tool_input(response)
+            parsed = parse_structured_response(structured_payload)
+
+            if parsed is None:
+                # Single retry with a sterner reminder to call the tool. A
+                # second failure falls through to the legacy parser below.
+                logger.warning("Anthropic structured response invalid; retrying once")
+                retry_content = list(content)
+                retry_content.append(
+                    {
+                        "type": "text",
+                        "text": (
+                            "Your previous reply was not a valid call to the "
+                            "submit_explanation tool. Re-emit the entire "
+                            "explanation by calling that tool with all "
+                            "required fields populated."
+                        ),
+                    }
+                )
+                response = self._client.messages.create(
+                    model=self._model,
+                    system=SYSTEM_PROMPT_STRUCTURED if gradcam_available else system_prompt,
+                    messages=[{"role": "user", "content": retry_content}],
+                    max_tokens=2000,
+                    temperature=0.3,
+                    tools=[tool],
+                    tool_choice={"type": "tool", "name": tool["name"]},
+                )
+                if response.usage:
+                    input_tokens = (input_tokens or 0) + response.usage.input_tokens
+                    output_tokens = (output_tokens or 0) + response.usage.output_tokens
+                    estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+                structured_payload = _extract_tool_input(response)
+                parsed = parse_structured_response(structured_payload)
+
+            processing_time = int((time.time() - start_time) * 1000)
+
+            if parsed is not None:
+                legacy = structured_to_legacy(parsed)
+                return VLMExplanation(
+                    summary=legacy["summary"],
+                    detailed_analysis=legacy["detailed_analysis"],
+                    technical_notes=legacy["technical_notes"] or None,
+                    region_comments=legacy["region_comments"] or None,
+                    structured_regions=parsed["regions"],
+                    provider="anthropic",
+                    model=self._model,
+                    processing_time_ms=processing_time,
+                    estimated_cost_usd=estimated_cost,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    raw_response=str(structured_payload) if structured_payload else None,
+                )
+
+            # Final fallback: scrape any text content the model returned and
+            # parse it with the legacy section parser.
+            logger.warning(
+                "Anthropic structured output failed twice; falling back to free-text parser"
+            )
+            raw_text = _extract_text(response)
             sections = parse_explanation_response(raw_text)
 
             return VLMExplanation(
@@ -208,3 +276,25 @@ class AnthropicProvider(BaseVLMProvider):
         except Exception as e:
             logger.warning(f"Anthropic health check failed: {e}")
             return False
+
+
+def _extract_tool_input(response) -> dict | None:
+    """Pull the first tool_use block's ``input`` from an Anthropic response."""
+    if not response or not getattr(response, "content", None):
+        return None
+    for block in response.content:
+        if getattr(block, "type", None) == "tool_use":
+            payload = getattr(block, "input", None)
+            return payload if isinstance(payload, dict) else None
+    return None
+
+
+def _extract_text(response) -> str:
+    """Concatenate every text block in an Anthropic response."""
+    if not response or not getattr(response, "content", None):
+        return ""
+    parts: list[str] = []
+    for block in response.content:
+        if getattr(block, "type", None) == "text":
+            parts.append(getattr(block, "text", "") or "")
+    return "\n".join(p for p in parts if p)

--- a/backend/app/services/vlm/providers/gemini.py
+++ b/backend/app/services/vlm/providers/gemini.py
@@ -12,11 +12,15 @@ from google.genai.errors import APIError
 from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInfo, VLMExplanation
 from app.services.vlm.config import ProviderConfig
 from app.services.vlm.prompt_builder import (
+    SYSTEM_PROMPT_STRUCTURED,
     SYSTEM_PROMPT_WITH_GRADCAM,
     SYSTEM_PROMPT_WITHOUT_GRADCAM,
     build_explanation_prompt,
     parse_explanation_response,
+    parse_structured_response,
+    structured_to_legacy,
 )
+from app.services.vlm.structured_schema import gemini_response_schema
 
 logger = logging.getLogger(__name__)
 
@@ -70,29 +74,77 @@ class GeminiProvider(BaseVLMProvider):
             for region_bytes in regions:
                 contents.append(types.Part.from_bytes(data=region_bytes, mime_type="image/jpeg"))
 
-            # Run the synchronous SDK call in a thread so it doesn't block the event loop
-            # (important when called in parallel with other providers via asyncio.gather)
+            # Preferred path: response_schema forces Gemini to emit JSON
+            # matching our schema. On hard validation failure we retry once,
+            # then fall back to the legacy text path so a single bad reply
+            # never breaks user-facing output.
+            structured_config = types.GenerateContentConfig(
+                system_instruction=(
+                    SYSTEM_PROMPT_STRUCTURED if gradcam_available else system_prompt
+                ),
+                max_output_tokens=2000,
+                temperature=0.3,
+                response_mime_type="application/json",
+                response_schema=gemini_response_schema(),
+            )
             response = await asyncio.to_thread(
                 self._client.models.generate_content,
                 model=self._model,
                 contents=contents,
-                config=types.GenerateContentConfig(
-                    system_instruction=system_prompt,
-                    max_output_tokens=2000,
-                    temperature=0.3,
-                ),
+                config=structured_config,
             )
 
+            input_tokens, output_tokens = _extract_usage(response)
+            estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+
             raw_text = response.text or ""
+            parsed = parse_structured_response(raw_text)
+
+            if parsed is None:
+                logger.warning("Gemini structured response invalid; retrying once")
+                retry_contents = list(contents) + [
+                    (
+                        "Your previous reply did not match the required JSON "
+                        "schema. Re-emit the entire explanation as a single "
+                        "JSON object matching the schema, with all required "
+                        "fields populated."
+                    )
+                ]
+                response = await asyncio.to_thread(
+                    self._client.models.generate_content,
+                    model=self._model,
+                    contents=retry_contents,
+                    config=structured_config,
+                )
+                retry_in, retry_out = _extract_usage(response)
+                input_tokens = (input_tokens or 0) + (retry_in or 0)
+                output_tokens = (output_tokens or 0) + (retry_out or 0)
+                estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+                raw_text = response.text or ""
+                parsed = parse_structured_response(raw_text)
+
             processing_time = int((time.time() - start_time) * 1000)
 
-            input_tokens = None
-            output_tokens = None
-            if response.usage_metadata:
-                input_tokens = response.usage_metadata.prompt_token_count
-                output_tokens = response.usage_metadata.candidates_token_count
+            if parsed is not None:
+                legacy = structured_to_legacy(parsed)
+                return VLMExplanation(
+                    summary=legacy["summary"],
+                    detailed_analysis=legacy["detailed_analysis"],
+                    technical_notes=legacy["technical_notes"] or None,
+                    region_comments=legacy["region_comments"] or None,
+                    structured_regions=parsed["regions"],
+                    provider="google",
+                    model=self._model,
+                    processing_time_ms=processing_time,
+                    estimated_cost_usd=estimated_cost,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    raw_response=raw_text,
+                )
 
-            estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+            logger.warning(
+                "Gemini structured output failed twice; falling back to free-text parser"
+            )
             sections = parse_explanation_response(raw_text)
 
             return VLMExplanation(
@@ -169,3 +221,14 @@ class GeminiProvider(BaseVLMProvider):
         except Exception as e:
             logger.warning(f"Gemini health check failed: {e}")
             return False
+
+
+def _extract_usage(response) -> tuple[int | None, int | None]:
+    """Pull (prompt_token_count, candidates_token_count) from a Gemini result."""
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None:
+        return None, None
+    return (
+        getattr(usage, "prompt_token_count", None),
+        getattr(usage, "candidates_token_count", None),
+    )

--- a/backend/app/services/vlm/providers/mock.py
+++ b/backend/app/services/vlm/providers/mock.py
@@ -108,10 +108,30 @@ class MockProvider(BaseVLMProvider):
 
         processing_time = int((time.time() - start_time) * 1000)
 
+        # Emit a minimal structured record for every labelled region so
+        # callers can rely on the same contract as the live VLM providers.
+        labels: list[str] = list(detection.region_labels or [])
+        if not labels and detection.region_categories:
+            labels = [getattr(r, "label", "") for r in detection.region_categories]
+        structured_regions = [
+            {
+                "region": label,
+                "observation": (
+                    f"Mock observation for {label} at {confidence_pct}% model confidence."
+                ),
+                "evidence_type": "heatmap",
+                "evidence_ref": f"GradCAM peak around {label}",
+                "confidence": 0.6,
+            }
+            for label in labels
+            if label
+        ]
+
         return VLMExplanation(
             summary=template["summary"],
             detailed_analysis=template["detailed_analysis"].format(confidence=confidence_pct),
             technical_notes=template["technical_notes"],
+            structured_regions=structured_regions or None,
             provider="mock",
             model="mock-v1",
             processing_time_ms=processing_time,

--- a/backend/app/services/vlm/providers/openai.py
+++ b/backend/app/services/vlm/providers/openai.py
@@ -11,11 +11,15 @@ from openai import APIError, APITimeoutError, OpenAI, RateLimitError
 from app.services.vlm.base import BaseVLMProvider, DetectionContext, ProviderInfo, VLMExplanation
 from app.services.vlm.config import ProviderConfig
 from app.services.vlm.prompt_builder import (
+    SYSTEM_PROMPT_STRUCTURED,
     SYSTEM_PROMPT_WITH_GRADCAM,
     SYSTEM_PROMPT_WITHOUT_GRADCAM,
     build_explanation_prompt,
     parse_explanation_response,
+    parse_structured_response,
+    structured_to_legacy,
 )
+from app.services.vlm.structured_schema import openai_response_format
 
 logger = logging.getLogger(__name__)
 
@@ -77,24 +81,83 @@ class OpenAIProvider(BaseVLMProvider):
             )
 
         try:
+            # Preferred path: strict json_schema response_format. The
+            # Responses API rejects malformed output before it reaches us, so
+            # parse_structured_response only fails if the model legitimately
+            # produced nonsense. On hard failure we fall back to the legacy
+            # text path so a single bad reply never breaks user-facing output.
+            response_format = openai_response_format()
             response = self._client.responses.create(
                 model=self._model,
-                instructions=system_prompt,
+                instructions=SYSTEM_PROMPT_STRUCTURED if gradcam_available else system_prompt,
                 input=[{"role": "user", "content": content}],
                 max_output_tokens=2000,
                 temperature=0.3,
+                text=response_format,
             )
 
+            input_tokens, output_tokens = _extract_usage(response)
+            estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+
             raw_text = response.output_text or ""
+            parsed = parse_structured_response(raw_text)
+
+            if parsed is None:
+                logger.warning("OpenAI structured response invalid; retrying once")
+                response = self._client.responses.create(
+                    model=self._model,
+                    instructions=SYSTEM_PROMPT_STRUCTURED if gradcam_available else system_prompt,
+                    input=[
+                        {"role": "user", "content": content},
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": (
+                                        "Your previous reply did not match the "
+                                        "required JSON schema. Re-emit the "
+                                        "entire explanation as a single JSON "
+                                        "object matching the schema, with all "
+                                        "required fields populated."
+                                    ),
+                                }
+                            ],
+                        },
+                    ],
+                    max_output_tokens=2000,
+                    temperature=0.3,
+                    text=response_format,
+                )
+                retry_in, retry_out = _extract_usage(response)
+                input_tokens = (input_tokens or 0) + (retry_in or 0)
+                output_tokens = (output_tokens or 0) + (retry_out or 0)
+                estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+                raw_text = response.output_text or ""
+                parsed = parse_structured_response(raw_text)
+
             processing_time = int((time.time() - start_time) * 1000)
 
-            input_tokens = None
-            output_tokens = None
-            if response.usage:
-                input_tokens = response.usage.input_tokens
-                output_tokens = response.usage.output_tokens
+            if parsed is not None:
+                legacy = structured_to_legacy(parsed)
+                return VLMExplanation(
+                    summary=legacy["summary"],
+                    detailed_analysis=legacy["detailed_analysis"],
+                    technical_notes=legacy["technical_notes"] or None,
+                    region_comments=legacy["region_comments"] or None,
+                    structured_regions=parsed["regions"],
+                    provider="openai",
+                    model=self._model,
+                    processing_time_ms=processing_time,
+                    estimated_cost_usd=estimated_cost,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    raw_response=raw_text,
+                )
 
-            estimated_cost = self.estimate_cost(input_tokens or 0, output_tokens or 0)
+            logger.warning(
+                "OpenAI structured output failed twice; falling back to free-text parser"
+            )
             sections = parse_explanation_response(raw_text)
 
             return VLMExplanation(
@@ -186,3 +249,11 @@ class OpenAIProvider(BaseVLMProvider):
         except Exception as e:
             logger.warning(f"OpenAI health check failed: {e}")
             return False
+
+
+def _extract_usage(response) -> tuple[int | None, int | None]:
+    """Pull (input_tokens, output_tokens) out of a Responses API result."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None, None
+    return getattr(usage, "input_tokens", None), getattr(usage, "output_tokens", None)

--- a/backend/app/services/vlm/providers/rule_based.py
+++ b/backend/app/services/vlm/providers/rule_based.py
@@ -319,6 +319,43 @@ def _build_region_comments(detection: DetectionContext) -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Structured-output records
+# ---------------------------------------------------------------------------
+
+
+def _build_structured_regions(detection: DetectionContext) -> list[dict]:
+    """Build the structured per-region records emitted by this provider.
+
+    Mirrors :func:`_build_region_comments` but yields the schema shape used by
+    the VLM providers, so callers and the frontend can treat all four
+    providers uniformly. Every claim is grounded in the GradCAM activation
+    score (``evidence_type='metric'``) since this provider has no access to
+    the image pixels.
+    """
+    regions = sorted(
+        detection.region_categories or [], key=lambda r: r.activation_score, reverse=True
+    )
+    out: list[dict] = []
+    for region in regions[:3]:
+        sentence = _build_region_comments(detection).get(region.label, "")
+        if not sentence:
+            continue
+        # Confidence tracks the model's overall confidence so the rule-based
+        # arm matches the calibration of the VLM arms; activation-derived
+        # ranking is encoded in evidence_ref.
+        out.append(
+            {
+                "region": region.label,
+                "observation": sentence,
+                "evidence_type": "metric",
+                "evidence_ref": f"activation={region.activation_score:.3f}",
+                "confidence": round(min(0.95, max(0.4, detection.confidence)), 2),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Technical notes
 # ---------------------------------------------------------------------------
 
@@ -412,12 +449,14 @@ class RuleBasedProvider(BaseVLMProvider):
         detailed = _build_detailed_analysis(detection)
         notes = _build_technical_notes(detection)
         region_comments = _build_region_comments(detection)
+        structured_regions = _build_structured_regions(detection)
 
         return VLMExplanation(
             summary=summary,
             detailed_analysis=detailed,
             technical_notes=notes,
             region_comments=region_comments if region_comments else None,
+            structured_regions=structured_regions if structured_regions else None,
             provider="rule_based",
             model="rule-based-v1",
             processing_time_ms=int((time.time() - start) * 1000),

--- a/backend/app/services/vlm/structured_schema.py
+++ b/backend/app/services/vlm/structured_schema.py
@@ -1,0 +1,173 @@
+"""
+Structured VLM output schema.
+
+Defines the JSON schema shared by every provider that supports schema-enforced
+output (Anthropic tool-use, OpenAI ``response_format=json_schema``, Gemini
+``response_schema``). Free-text providers (mock / rule_based) emit objects of
+this same shape so downstream code can treat all providers uniformly.
+
+The per-region object carries an ``evidence_type`` tag — ``"visual"``,
+``"metric"``, or ``"heatmap"`` — and an ``evidence_ref`` string that names the
+specific cue. The frontend uses these to highlight the cited metric strip,
+heatmap region, or crop alongside the prose claim, turning the explanation
+from "VLM with nice prose" into "auditable evidence with a paper trail".
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# The allowed evidence-type tags. Kept as a tuple so it can be reused as a
+# JSON Schema enum, a Python validator set, and a Pydantic ``Literal[...]``.
+EVIDENCE_TYPES: Final[tuple[str, ...]] = ("visual", "metric", "heatmap")
+
+
+# Canonical JSON Schema for one region claim. Provider adapters reuse this and
+# wrap or transform it as their API requires.
+REGION_SCHEMA: Final[dict] = {
+    "type": "object",
+    "properties": {
+        "region": {
+            "type": "string",
+            "description": (
+                "Human-readable region label exactly as it appeared in the "
+                "[REGIONS] list of the user prompt (e.g. 'Skin Texture')."
+            ),
+        },
+        "observation": {
+            "type": "string",
+            "description": (
+                "One to three sentences describing what you actually see or "
+                "measure for this region. No filler."
+            ),
+        },
+        "evidence_type": {
+            "type": "string",
+            "enum": list(EVIDENCE_TYPES),
+            "description": (
+                "What grounds the observation: 'visual' = a cue you see in a "
+                "crop or in the original photo; 'metric' = a value cited from "
+                "the [FORENSIC EVIDENCE] block; 'heatmap' = a pattern visible "
+                "in the GradCAM or ELA overlay."
+            ),
+        },
+        "evidence_ref": {
+            "type": "string",
+            "description": (
+                "Specific reference for the evidence: when 'metric', cite the "
+                "metric name and value (e.g. 'sharpness_z=-3.8'); when "
+                "'visual' or 'heatmap', name the area (e.g. 'left jaw crop' "
+                "or 'GradCAM peak around the mouth'). Empty string allowed "
+                "only when no specific anchor exists."
+            ),
+        },
+        "confidence": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": (
+                "Your confidence in this observation in [0, 1]. Use lower "
+                "values when the cue is subtle or ambiguous."
+            ),
+        },
+    },
+    "required": ["region", "observation", "evidence_type", "evidence_ref", "confidence"],
+    "additionalProperties": False,
+}
+
+
+# Top-level schema returned by the VLM.
+EXPLANATION_SCHEMA: Final[dict] = {
+    "type": "object",
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "One sentence stating what was found and where.",
+        },
+        "detailed_analysis": {
+            "type": "string",
+            "description": (
+                "Two to three sentences describing the most distinctive thing "
+                "that makes this image look real or fake."
+            ),
+        },
+        "technical_notes": {
+            "type": "string",
+            "description": ("Three to five lines of forensic notes for a technical reader."),
+        },
+        "regions": {
+            "type": "array",
+            "items": REGION_SCHEMA,
+            "description": (
+                "One entry per facial region you commented on. Cover at least "
+                "the regions listed in the user prompt; you may add more if "
+                "you spotted something noteworthy outside the heatmap."
+            ),
+        },
+    },
+    "required": ["summary", "detailed_analysis", "technical_notes", "regions"],
+    "additionalProperties": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Provider-specific adapters
+# ---------------------------------------------------------------------------
+
+
+def anthropic_tool_definition() -> dict:
+    """Return the Anthropic tool-use tool definition for structured output.
+
+    Anthropic enforces JSON shape via tool_use: the assistant must call this
+    tool with arguments matching ``input_schema``. We pin tool_choice to this
+    tool so the model cannot reply with free text.
+    """
+    return {
+        "name": "submit_explanation",
+        "description": (
+            "Submit the structured deepfake explanation. Every region claim "
+            "must have a non-empty evidence_ref unless evidence_type implies "
+            "no specific anchor exists."
+        ),
+        "input_schema": EXPLANATION_SCHEMA,
+    }
+
+
+def openai_response_format() -> dict:
+    """Return the OpenAI Responses API ``text.format`` block.
+
+    Uses strict json_schema mode so the API rejects malformed output before
+    it reaches us.
+    """
+    return {
+        "format": {
+            "type": "json_schema",
+            "name": "DeepfakeExplanation",
+            "schema": EXPLANATION_SCHEMA,
+            "strict": True,
+        }
+    }
+
+
+def gemini_response_schema() -> dict:
+    """Return the Gemini-compatible response_schema dict.
+
+    The genai SDK accepts a plain Python dict mirroring the JSON Schema with
+    a few extensions (``propertyOrdering`` etc.). We keep it minimal — the
+    canonical schema is enough.
+    """
+
+    # Gemini does not support additionalProperties=False; strip it so the
+    # SDK does not reject the schema.
+    def _strip_additional_properties(node: dict) -> dict:
+        out = {k: v for k, v in node.items() if k != "additionalProperties"}
+        if "properties" in out:
+            out["properties"] = {
+                name: _strip_additional_properties(prop) if isinstance(prop, dict) else prop
+                for name, prop in out["properties"].items()
+            }
+        if "items" in out and isinstance(out["items"], dict):
+            out["items"] = _strip_additional_properties(out["items"])
+        return out
+
+    return _strip_additional_properties(EXPLANATION_SCHEMA)

--- a/backend/tests/test_attach_region_comments.py
+++ b/backend/tests/test_attach_region_comments.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for ``_attach_region_comments`` in ``app.routers.analyses``.
+
+Coverage:
+- Backwards compat — the legacy region_comments-only path still attaches
+  ``explanation`` to evidence regions and leaves the new fields unset.
+- Structured-regions path — when present, evidence_type / evidence_ref /
+  claim_confidence are attached and ``explanation`` is overridden by the
+  structured ``observation``.
+- Label match is whitespace- and case-insensitive so minor casing drift
+  between provider output and our region labels does not silently drop
+  the tag.
+"""
+
+from __future__ import annotations
+
+from app.routers.analyses import _attach_region_comments
+
+
+def _evidence(label: str = "Skin Texture") -> dict:
+    return {"url": "/x.png", "label": label, "activation_score": 0.6}
+
+
+class TestAttachRegionComments:
+    def test_legacy_only_attaches_explanation(self):
+        out = _attach_region_comments(
+            [_evidence()],
+            {"Skin Texture": "Looks waxy."},
+        )
+        assert out[0]["explanation"] == "Looks waxy."
+        assert "evidence_type" not in out[0]
+        assert "evidence_ref" not in out[0]
+        assert "claim_confidence" not in out[0]
+
+    def test_missing_legacy_label_yields_none_explanation(self):
+        out = _attach_region_comments([_evidence()], {})
+        assert out[0]["explanation"] is None
+
+    def test_structured_regions_attach_evidence_fields(self):
+        structured = [
+            {
+                "region": "Skin Texture",
+                "observation": "No visible pores across the cheeks.",
+                "evidence_type": "metric",
+                "evidence_ref": "sharpness_z=-3.8",
+                "confidence": 0.85,
+            }
+        ]
+        out = _attach_region_comments(
+            [_evidence()],
+            {"Skin Texture": "legacy text"},
+            structured_regions=structured,
+        )
+        # observation overrides legacy text.
+        assert out[0]["explanation"] == "No visible pores across the cheeks."
+        assert out[0]["evidence_type"] == "metric"
+        assert out[0]["evidence_ref"] == "sharpness_z=-3.8"
+        assert out[0]["claim_confidence"] == 0.85
+
+    def test_label_match_is_case_insensitive(self):
+        structured = [
+            {
+                "region": "skin texture",
+                "observation": "Different casing.",
+                "evidence_type": "visual",
+                "evidence_ref": "left cheek crop",
+                "confidence": 0.5,
+            }
+        ]
+        out = _attach_region_comments(
+            [_evidence("Skin Texture")],
+            {},
+            structured_regions=structured,
+        )
+        assert out[0]["evidence_type"] == "visual"
+        assert out[0]["evidence_ref"] == "left cheek crop"
+
+    def test_unmatched_structured_region_does_not_break_others(self):
+        """A structured record for a region we don't show should be ignored."""
+        structured = [
+            {
+                "region": "Mouth & Teeth",
+                "observation": "Different region.",
+                "evidence_type": "metric",
+                "evidence_ref": "ela_z=+2.9",
+                "confidence": 0.9,
+            }
+        ]
+        out = _attach_region_comments(
+            [_evidence("Skin Texture")],
+            {"Skin Texture": "legacy"},
+            structured_regions=structured,
+        )
+        # Skin Texture gets the legacy explanation, no evidence fields.
+        assert out[0]["explanation"] == "legacy"
+        assert "evidence_type" not in out[0]
+
+    def test_invalid_confidence_does_not_break_attachment(self):
+        structured = [
+            {
+                "region": "Skin Texture",
+                "observation": "Has observation.",
+                "evidence_type": "visual",
+                "evidence_ref": "left cheek",
+                "confidence": "not-a-number",
+            }
+        ]
+        out = _attach_region_comments([_evidence()], {}, structured_regions=structured)
+        assert out[0]["explanation"] == "Has observation."
+        assert out[0]["evidence_type"] == "visual"
+        assert "claim_confidence" not in out[0]

--- a/backend/tests/test_structured_schema.py
+++ b/backend/tests/test_structured_schema.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for the structured VLM output schema and validator.
+
+Coverage:
+- ``parse_structured_response`` — accepts dicts and JSON strings, rejects
+  malformed inputs, and clamps soft errors instead of failing.
+- ``structured_to_legacy`` — produces the flat shape consumed by today's
+  callers.
+- Provider schema adapters — return dicts in the shapes each SDK expects.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.services.vlm.prompt_builder import (
+    parse_structured_response,
+    structured_to_legacy,
+)
+from app.services.vlm.structured_schema import (
+    EVIDENCE_TYPES,
+    EXPLANATION_SCHEMA,
+    REGION_SCHEMA,
+    anthropic_tool_definition,
+    gemini_response_schema,
+    openai_response_format,
+)
+
+
+def _valid_payload() -> dict:
+    return {
+        "summary": "The face looks fake.",
+        "detailed_analysis": "Skin is too smooth across the cheeks.",
+        "technical_notes": "Sharpness z=-3.8 in skin region.",
+        "regions": [
+            {
+                "region": "Skin Texture",
+                "observation": "Skin across the cheeks has no visible pores.",
+                "evidence_type": "metric",
+                "evidence_ref": "sharpness_z=-3.8",
+                "confidence": 0.85,
+            }
+        ],
+    }
+
+
+class TestParseStructuredResponse:
+    def test_accepts_dict_payload(self):
+        parsed = parse_structured_response(_valid_payload())
+        assert parsed is not None
+        assert parsed["summary"] == "The face looks fake."
+        assert len(parsed["regions"]) == 1
+        assert parsed["regions"][0]["region"] == "Skin Texture"
+
+    def test_accepts_json_string(self):
+        payload = json.dumps(_valid_payload())
+        parsed = parse_structured_response(payload)
+        assert parsed is not None
+        assert parsed["regions"][0]["evidence_type"] == "metric"
+
+    def test_rejects_none(self):
+        assert parse_structured_response(None) is None
+
+    def test_rejects_malformed_json(self):
+        assert parse_structured_response("{ not json") is None
+
+    def test_rejects_non_object_payload(self):
+        assert parse_structured_response([1, 2, 3]) is None
+
+    def test_rejects_missing_top_level_key(self):
+        payload = _valid_payload()
+        del payload["summary"]
+        assert parse_structured_response(payload) is None
+
+    def test_rejects_regions_not_list(self):
+        payload = _valid_payload()
+        payload["regions"] = {"not": "a list"}
+        assert parse_structured_response(payload) is None
+
+    def test_rejects_unknown_evidence_type(self):
+        payload = _valid_payload()
+        payload["regions"][0]["evidence_type"] = "guess"
+        assert parse_structured_response(payload) is None
+
+    def test_rejects_region_missing_field(self):
+        payload = _valid_payload()
+        del payload["regions"][0]["evidence_ref"]
+        assert parse_structured_response(payload) is None
+
+    def test_rejects_non_numeric_confidence(self):
+        payload = _valid_payload()
+        payload["regions"][0]["confidence"] = "high"
+        assert parse_structured_response(payload) is None
+
+    def test_clamps_out_of_range_confidence(self):
+        """Soft failure: clamp rather than burn a retry."""
+        payload = _valid_payload()
+        payload["regions"][0]["confidence"] = 1.4
+        parsed = parse_structured_response(payload)
+        assert parsed is not None
+        assert parsed["regions"][0]["confidence"] == 1.0
+
+        payload["regions"][0]["confidence"] = -0.2
+        parsed = parse_structured_response(payload)
+        assert parsed is not None
+        assert parsed["regions"][0]["confidence"] == 0.0
+
+    def test_high_confidence_with_empty_ref_is_logged_not_failed(self):
+        """The grounding rule is enforced upstream by the prompt — at parse
+        time we keep the claim and let the frontend flag it."""
+        payload = _valid_payload()
+        payload["regions"][0]["evidence_ref"] = ""
+        payload["regions"][0]["confidence"] = 0.9
+        parsed = parse_structured_response(payload)
+        assert parsed is not None
+        assert parsed["regions"][0]["evidence_ref"] == ""
+        assert parsed["regions"][0]["confidence"] == 0.9
+
+    def test_normalises_markdown_region_label(self):
+        """Reuses the existing label normaliser so providers that wrap
+        labels in bold (`**Skin Texture**`) do not break attachment."""
+        payload = _valid_payload()
+        payload["regions"][0]["region"] = "**Skin Texture**"
+        parsed = parse_structured_response(payload)
+        assert parsed is not None
+        assert parsed["regions"][0]["region"] == "Skin Texture"
+
+
+class TestStructuredToLegacy:
+    def test_round_trip(self):
+        parsed = parse_structured_response(_valid_payload())
+        legacy = structured_to_legacy(parsed)
+        assert legacy["summary"] == "The face looks fake."
+        assert legacy["region_comments"] == {
+            "Skin Texture": "Skin across the cheeks has no visible pores."
+        }
+
+
+class TestProviderAdapters:
+    def test_anthropic_tool_definition_shape(self):
+        tool = anthropic_tool_definition()
+        assert tool["name"] == "submit_explanation"
+        assert tool["input_schema"] is EXPLANATION_SCHEMA
+
+    def test_openai_response_format_strict_json_schema(self):
+        fmt = openai_response_format()
+        assert fmt["format"]["type"] == "json_schema"
+        assert fmt["format"]["strict"] is True
+        assert fmt["format"]["schema"]["properties"]["regions"]["items"] is REGION_SCHEMA
+
+    def test_gemini_strips_additional_properties(self):
+        """Gemini rejects ``additionalProperties`` so the adapter strips it."""
+        schema = gemini_response_schema()
+
+        def _walk(node):
+            if isinstance(node, dict):
+                assert "additionalProperties" not in node
+                for v in node.values():
+                    _walk(v)
+            elif isinstance(node, list):
+                for item in node:
+                    _walk(item)
+
+        _walk(schema)
+        # Spot-check the structure is otherwise intact.
+        assert schema["properties"]["regions"]["items"]["properties"]["evidence_type"][
+            "enum"
+        ] == list(EVIDENCE_TYPES)


### PR DESCRIPTION
Three live providers (Anthropic / OpenAI / Gemini) now request schema-
enforced JSON via tool-use / json_schema / response_schema. Each region
claim carries an evidence_type ("visual" | "metric" | "heatmap"), an
evidence_ref naming the specific cue, and a confidence in [0, 1]. The
frontend can use these to highlight the cited metric strip, heatmap
region, or crop alongside the prose.

parse_structured_response() validates and normalises the response. Hard
failures (malformed JSON, missing fields, unknown evidence_type) trigger
a single retry; a second failure falls back to the legacy free-text
parser so a bad reply never breaks user-facing output. Soft issues
(out-of-range confidence) are clamped without burning a retry.

Mock and rule_based providers emit the same schema directly so all four
arms of the user study deliver a uniform contract.

EvidenceRegion gains optional evidence_type / evidence_ref /
claim_confidence fields; older persisted analyses deserialise cleanly.

Closes #85