### PR TITLE
fix(study): remove "Skip for now" link from IntroScreen

### DIFF
--- a/desktop/src/components/auth/DeepfakeTest.tsx
+++ b/desktop/src/components/auth/DeepfakeTest.tsx
@@ -188,16 +188,6 @@ function IntroScreen({ onStart }: { onStart: () => void }) {
             <ArrowRight className="h-4 w-4" />
           </button>
         </div>
-
-        <button
-          onClick={() => {
-            localStorage.setItem('xade-test-completed', 'skipped');
-            window.location.reload();
-          }}
-          className="mt-4 block w-full text-center text-xs text-xade-charcoal/30 hover:text-xade-charcoal/50"
-        >
-          Skip for now
-        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
The link sat under the "Start the study" button and let participants skip the entire flow by setting xade-test-completed=skipped in localStorage and reloading. That bypassed all 12 classifications, both explanation reviews, and the closing survey, leaving an empty row in study_results — pure dev convenience that has no business in production. Developers who need to skip can clear localStorage from DevTools or use the dev toolbar's Reset Quiz button (still available in dev mode).