### PR TITLE
feat(study): update intro to show 4 phases and renumber survey to Phase 4

### DIFF
--- a/desktop/src/components/auth/DeepfakeTest.tsx
+++ b/desktop/src/components/auth/DeepfakeTest.tsx
@@ -159,6 +159,11 @@ function IntroScreen({ onStart }: { onStart: () => void }) {
               },
               {
                 step: '3',
+                title: 'Try 3 more images',
+                desc: 'Now that you have seen our explanations, try classifying 3 new images.',
+              },
+              {
+                step: '4',
                 title: 'A few final questions',
                 desc: 'Answer a few short questions about your experience.',
               },
@@ -507,7 +512,7 @@ function ExplanationScreen({
 }
 
 // ============================================
-// Phase: Closing survey (Phase 3)
+// Phase: Closing survey (Phase 4)
 // ============================================
 function SurveyScreen({
   onSubmit,
@@ -525,7 +530,7 @@ function SurveyScreen({
       <div className="w-full max-w-lg">
         <div className="rounded-2xl border border-xade-charcoal/6 bg-white px-8 py-8 shadow-lg shadow-xade-charcoal/4">
           <p className="text-xs font-medium uppercase tracking-widest text-xade-blue/60">
-            Phase 3: Final Questions
+            Phase 4: Final Questions
           </p>
           <h2 className="mt-2 text-xl font-semibold text-xade-charcoal">Almost done</h2>
           <p className="mt-1 text-sm text-xade-charcoal/50">


### PR DESCRIPTION
Closes #115

The IntroScreen step list now has four entries instead of three. Step 3 is the new 'Try 3 more images' placeholder for the retest phase that lands in #116. The closing survey header changes from 'Phase 3: Final Questions' to 'Phase 4: Final Questions' so the numbering stays consistent end-to-end.

Note this issue depends on #116. Until that lands, participants will read about a Phase 3 in the intro that the app does not actually run. The two should ship together, with #116 merging first or simultaneously.