### PR TITLE
feat(study): add did explanations help in retest? question to Phase 4

### DIFF
--- a/backend/app/routers/study.py
+++ b/backend/app/routers/study.py
@@ -95,6 +95,9 @@ class StudyResults(BaseModel):
     retest_answers: list[dict] = []
     trust_rating: int
     willingness_to_use: str  # "yes" | "no" | "maybe"
+    # 1–5 rating shown only to participants who took the retest. None
+    # when the retest was skipped.
+    explanations_helped_in_retest: int | None = None
     comments: str
     completed_at: str
 

--- a/backend/scripts/show_study_results.py
+++ b/backend/scripts/show_study_results.py
@@ -202,6 +202,20 @@ def aggregate_block(rows: list[dict]) -> None:
             print(f"  Avg retest accuracy:       {fmt_pct(avg_retest)}")
             print(f"  Improvement (retest − P1): {improvement:+.1f} pp")
 
+        # Self-reported "did the explanations help" — only meaningful for
+        # participants who took the retest, so filter on retest_rows.
+        helped_vals = [
+            r.get("explanations_helped_in_retest")
+            for r in retest_rows
+            if r.get("explanations_helped_in_retest") is not None
+        ]
+        if helped_vals:
+            avg_helped = sum(helped_vals) / len(helped_vals)
+            print(
+                f"  Self-reported help rating: avg {avg_helped:.1f}/5  "
+                f"({len(helped_vals)} participants)"
+            )
+
 
 def dump_comments(rows: list[dict]) -> None:
     print("\nFinal-survey comments")

--- a/desktop/src/components/auth/DeepfakeTest.tsx
+++ b/desktop/src/components/auth/DeepfakeTest.tsx
@@ -607,15 +607,28 @@ function RetestScreen({
 // Phase: Closing survey (Phase 4)
 // ============================================
 function SurveyScreen({
+  didRetest,
   onSubmit,
 }: {
-  onSubmit: (answers: { trustRating: number; willingnessToUse: string; comments: string }) => void;
+  didRetest: boolean;
+  onSubmit: (answers: {
+    trustRating: number;
+    willingnessToUse: string;
+    explanationsHelpedInRetest: number | null;
+    comments: string;
+  }) => void;
 }) {
   const [trust, setTrust] = useState<number | null>(null);
   const [willingness, setWillingness] = useState<string | null>(null);
+  // Only required when the participant actually took Phase 3.
+  const [helpedInRetest, setHelpedInRetest] = useState<number | null>(null);
   const [comments, setComments] = useState('');
 
-  const canSubmit = trust !== null && willingness !== null;
+  const canSubmit =
+    trust !== null && willingness !== null && (!didRetest || helpedInRetest !== null);
+
+  // Q-numbers shift by one when the retest question is hidden.
+  const commentsQNumber = didRetest ? 4 : 3;
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-xade-cream p-8">
@@ -665,10 +678,27 @@ function SurveyScreen({
             </div>
           </div>
 
-          {/* Q3: Open text */}
+          {/* Q3: Did our explanations help in the retest? — only shown when
+              the participant actually took Phase 3. */}
+          {didRetest && (
+            <div className="mt-6">
+              <p className="text-sm font-medium text-xade-charcoal">
+                3. Did our explanations help you in the second round of images?
+              </p>
+              <div className="mt-3">
+                <RatingButtons
+                  value={helpedInRetest}
+                  onChange={setHelpedInRetest}
+                  labels={['Not at all', 'Definitely']}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Comments — Q3 if no retest, Q4 otherwise. */}
           <div className="mt-6">
             <p className="text-sm font-medium text-xade-charcoal">
-              3. Any other comments? (optional)
+              {commentsQNumber}. Any other comments? (optional)
             </p>
             <p className="mt-1 text-xs text-xade-charcoal/40">
               You can write in Swedish if you prefer.
@@ -689,6 +719,7 @@ function SurveyScreen({
               onSubmit({
                 trustRating: trust!,
                 willingnessToUse: willingness!,
+                explanationsHelpedInRetest: didRetest ? helpedInRetest : null,
                 comments,
               })
             }
@@ -977,6 +1008,7 @@ export default function DeepfakeTest({ onComplete }: DeepfakeTestProps) {
   async function handleSurveySubmit(answers: {
     trustRating: number;
     willingnessToUse: string;
+    explanationsHelpedInRetest: number | null;
     comments: string;
   }) {
     const correct = classificationRecords.filter((r) => r.isCorrect).length;
@@ -1004,6 +1036,7 @@ export default function DeepfakeTest({ onComplete }: DeepfakeTestProps) {
       })),
       trust_rating: answers.trustRating,
       willingness_to_use: answers.willingnessToUse,
+      explanations_helped_in_retest: answers.explanationsHelpedInRetest,
       comments: answers.comments,
       completed_at: new Date().toISOString(),
     };
@@ -1064,7 +1097,10 @@ export default function DeepfakeTest({ onComplete }: DeepfakeTestProps) {
       />
     );
 
-  if (phase === 'survey') return <SurveyScreen onSubmit={handleSurveySubmit} />;
+  if (phase === 'survey')
+    return (
+      <SurveyScreen didRetest={retestRecords.length > 0} onSubmit={handleSurveySubmit} />
+    );
 
   return (
     <CompleteScreen

--- a/desktop/src/components/auth/DeepfakeTest.tsx
+++ b/desktop/src/components/auth/DeepfakeTest.tsx
@@ -1098,9 +1098,7 @@ export default function DeepfakeTest({ onComplete }: DeepfakeTestProps) {
     );
 
   if (phase === 'survey')
-    return (
-      <SurveyScreen didRetest={retestRecords.length > 0} onSubmit={handleSurveySubmit} />
-    );
+    return <SurveyScreen didRetest={retestRecords.length > 0} onSubmit={handleSurveySubmit} />;
 
   return (
     <CompleteScreen

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -347,6 +347,9 @@ export interface StudyResultsPayload {
   retest_answers: object[];
   trust_rating: number;
   willingness_to_use: string;
+  // 1–5 rating shown only to participants who took Phase 3. null when
+  // the retest was skipped (no Phase 1 misclassifications).
+  explanations_helped_in_retest: number | null;
   comments: string;
   completed_at: string;
 }
@@ -389,6 +392,7 @@ export async function saveStudyResults(payload: StudyResultsPayload): Promise<vo
       retest_answers: payload.retest_answers,
       trust_rating: payload.trust_rating,
       willingness_to_use: payload.willingness_to_use,
+      explanations_helped_in_retest: payload.explanations_helped_in_retest,
       comments: payload.comments,
       completed_at: payload.completed_at,
     });


### PR DESCRIPTION
Closes #117

Adds a new Q3 to the closing survey asking participants whether our
explanations helped them on the Phase 3 retest. This is the
self-reported counterpart to the behavioural improvement data captured
by the retest answers themselves — together they let us cross-validate
"did participants get better?" against "did participants think they
got better?"

Frontend (DeepfakeTest.tsx):
- SurveyScreen accepts a new didRetest: boolean prop. When true, a new
  1–5 rating question is rendered between the willingness Q and the
  free-text comments. When false (the participant skipped Phase 3),
  the question is hidden and the comments field renumbers to Q3.
- Submit is gated on the new rating only when didRetest is true.
- The orchestrator passes retestRecords.length > 0 as didRetest.
- handleSurveySubmit's payload now carries explanations_helped_in_retest
  (number when shown, null when skipped).

Types + Supabase (api.ts):
- StudyResultsPayload gains explanations_helped_in_retest: number | null.
- saveStudyResults threads it into the supabase insert.

Backend (study.py):
- StudyResults Pydantic model gains
  explanations_helped_in_retest: int | None = None.

Tooling (show_study_results.py):
- New aggregate line under the Phase 3 retest block:
  "Self-reported help rating: avg X.X/5 (N participants)".
- Filters on retest_rows so participants who skipped Phase 3 do not
  pollute the average with their null answers